### PR TITLE
Render TFC ingots using their mod textures if valid

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/TFGClientHelpers.java
+++ b/src/main/java/su/terrafirmagreg/core/client/TFGClientHelpers.java
@@ -11,7 +11,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 public final class TFGClientHelpers {
-
     /**
      * Просто скопированный метод из RenderHelper.java (TFC) + добавленный аргумент для цвета.
      * */
@@ -61,11 +60,15 @@ public final class TFGClientHelpers {
 
     /**
      * Просто скопированный метод из RenderHelper.java (TFC) + добавленный аргумент для цвета.
+     * airrice: Updated this to also use the side shading (TFC)
      * */
     public static void renderTexturedVertex(PoseStack poseStack, VertexConsumer buffer, int packedLight, int packedOverlay, float x, float y, float z, float u, float v, float normalX, float normalY, float normalZ, int color1, int color2)
     {
+        final int pColor =  increaseBrightness(FastColor.ARGB32.multiply(color1, color2), 90);
+        final int shadeToInt = (int)(RenderHelpers.getShade(normalX, normalY, normalZ) * 255);
+        final int pColor2 = FastColor.ARGB32.multiply(pColor, FastColor.ARGB32.color(255, shadeToInt,shadeToInt,shadeToInt));
         buffer.vertex(poseStack.last().pose(), x, y, z)
-                .color(increaseBrightness(FastColor.ARGB32.multiply(color1, color2), 90))
+                .color(pColor2)
                 .uv(u, v)
                 .uv2(packedLight)
                 .overlayCoords(packedOverlay)
@@ -91,5 +94,4 @@ public final class TFGClientHelpers {
         // Собираем новое ARGB значение
         return (alpha << 24) | (0xFF000000 | (red << 16) | (green << 8) | blue);
     }
-
 }

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/DoubleIngotPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/DoubleIngotPileBlockModelMixin.java
@@ -10,6 +10,7 @@ import net.dries007.tfc.client.model.DoubleIngotPileBlockModel;
 import net.dries007.tfc.client.model.SimpleStaticBlockEntityModel;
 import net.dries007.tfc.common.blockentities.IngotPileBlockEntity;
 import net.dries007.tfc.common.blocks.devices.DoubleIngotPileBlock;
+import net.dries007.tfc.util.Metal;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
@@ -48,8 +49,12 @@ public abstract class DoubleIngotPileBlockModelMixin implements SimpleStaticBloc
             final var material = ChemicalHelper.getMaterial(stack);
             final int primaryColor = material == null ? 0 : material.material().getMaterialARGB(0);
             final int secondaryColor = material == null ? 0 : material.material().getMaterialARGB(1);
+            Metal metalAtPos = pile.getOrCacheMetal(i);
 
-            sprite = textureAtlas.apply(TFGClientEventHandler.TFCMetalBlockTexturePattern);
+            boolean shouldUseTFCRender = !(metalAtPos.getId() == Metal.unknown().getId() && material != null && !material.isEmpty());
+            ResourceLocation metalResource = shouldUseTFCRender ? metalAtPos.getSoftTextureId() : TFGClientEventHandler.TFCMetalBlockTexturePattern;
+
+            sprite = textureAtlas.apply(metalResource);
 
             final int layer = (i + 6) / 6;
             final boolean oddLayer = (layer % 2) == 1;
@@ -75,9 +80,12 @@ public abstract class DoubleIngotPileBlockModelMixin implements SimpleStaticBloc
             final float maxX = scale * (minX + 10);
             final float maxY = scale * (minY + 5);
             final float maxZ = scale * (minZ + 15);
-
-            TFGClientHelpers.renderTexturedTrapezoidalCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, minX, maxX, minZ, maxZ, minX + scale, maxX - scale, minZ + scale, maxZ - scale, minY, maxY, 10, 5, 15, oddLayer, primaryColor, secondaryColor);
-
+            if (shouldUseTFCRender)
+                RenderHelpers.renderTexturedTrapezoidalCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, minX, maxX, minZ, maxZ, minX + scale, maxX - scale, minZ + scale, maxZ - scale, minY, maxY, 10.0F, 5.0F, 15.0F, oddLayer);
+            else
+            {
+                TFGClientHelpers.renderTexturedTrapezoidalCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, minX, maxX, minZ, maxZ, minX + scale, maxX - scale, minZ + scale, maxZ - scale, minY, maxY, 10, 5, 15, oddLayer, primaryColor, secondaryColor);
+            }
             poseStack.popPose();
         }
 

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
@@ -1,6 +1,7 @@
 package su.terrafirmagreg.core.mixins.client.tfc;
 
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -49,11 +50,15 @@ public abstract class IngotPileBlockModelMixin implements SimpleStaticBlockEntit
             final var material = ChemicalHelper.getMaterial(stack);
             final int primaryColor = material == null ? 0 : material.material().getMaterialARGB(0);
             final int secondaryColor = material == null ? 0 : material.material().getMaterialARGB(1);
-            ResourceLocation metalResource = pile.getOrCacheMetal(i).getSoftTextureId();
-            boolean shouldUseTFCRender = ResourceLocation.isValidResourceLocation(metalResource.getPath());
-            if (!shouldUseTFCRender)
+            Metal metalAtPos = pile.getOrCacheMetal(i);
+
+            boolean shouldUseTFCRender = !(metalAtPos.getId() == Metal.unknown().getId() && material != null && !material.isEmpty());
+            ResourceLocation metalResource = shouldUseTFCRender ? metalAtPos.getSoftTextureId() : TFGClientEventHandler.TFCMetalBlockTexturePattern;
+            if (!ResourceLocation.isValidResourceLocation(metalResource.getPath()))
             {
+                // Fallback if the texture being referenced doesn't actually exist.
                 metalResource = TFGClientEventHandler.TFCMetalBlockTexturePattern;
+                shouldUseTFCRender = false;
             }
             sprite = textureAtlas.apply(metalResource);
 

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
@@ -54,12 +54,7 @@ public abstract class IngotPileBlockModelMixin implements SimpleStaticBlockEntit
 
             boolean shouldUseTFCRender = !(metalAtPos.getId() == Metal.unknown().getId() && material != null && !material.isEmpty());
             ResourceLocation metalResource = shouldUseTFCRender ? metalAtPos.getSoftTextureId() : TFGClientEventHandler.TFCMetalBlockTexturePattern;
-            if (!ResourceLocation.isValidResourceLocation(metalResource.getPath()))
-            {
-                // Fallback if the texture being referenced doesn't actually exist.
-                metalResource = TFGClientEventHandler.TFCMetalBlockTexturePattern;
-                shouldUseTFCRender = false;
-            }
+
             sprite = textureAtlas.apply(metalResource);
 
             final int layer = (i + 8) / 8;

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
@@ -1,7 +1,6 @@
 package su.terrafirmagreg.core.mixins.client.tfc;
 
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
-import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/IngotPileBlockModelMixin.java
@@ -10,6 +10,7 @@ import net.dries007.tfc.client.model.IngotPileBlockModel;
 import net.dries007.tfc.client.model.SimpleStaticBlockEntityModel;
 import net.dries007.tfc.common.blockentities.IngotPileBlockEntity;
 import net.dries007.tfc.common.blocks.devices.IngotPileBlock;
+import net.dries007.tfc.util.Metal;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
@@ -48,8 +49,13 @@ public abstract class IngotPileBlockModelMixin implements SimpleStaticBlockEntit
             final var material = ChemicalHelper.getMaterial(stack);
             final int primaryColor = material == null ? 0 : material.material().getMaterialARGB(0);
             final int secondaryColor = material == null ? 0 : material.material().getMaterialARGB(1);
-
-            sprite = textureAtlas.apply(TFGClientEventHandler.TFCMetalBlockTexturePattern);
+            ResourceLocation metalResource = pile.getOrCacheMetal(i).getSoftTextureId();
+            boolean shouldUseTFCRender = ResourceLocation.isValidResourceLocation(metalResource.getPath());
+            if (!shouldUseTFCRender)
+            {
+                metalResource = TFGClientEventHandler.TFCMetalBlockTexturePattern;
+            }
+            sprite = textureAtlas.apply(metalResource);
 
             final int layer = (i + 8) / 8;
             final boolean oddLayer = (layer % 2) == 1;
@@ -76,7 +82,10 @@ public abstract class IngotPileBlockModelMixin implements SimpleStaticBlockEntit
             final float maxY = scale * (minY + 4);
             final float maxZ = scale * (minZ + 15);
 
-            TFGClientHelpers.renderTexturedTrapezoidalCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, minX, maxX, minZ, maxZ, minX + scale, maxX - scale, minZ + scale, maxZ - scale, minY, maxY, 7, 4, 15, oddLayer, primaryColor, secondaryColor);
+            if (shouldUseTFCRender)
+                RenderHelpers.renderTexturedTrapezoidalCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, minX, maxX, minZ, maxZ, minX + scale, maxX - scale, minZ + scale, maxZ - scale, minY, maxY, 7.0F, 4.0F, 15.0F, oddLayer);
+            else
+                TFGClientHelpers.renderTexturedTrapezoidalCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, minX, maxX, minZ, maxZ, minX + scale, maxX - scale, minZ + scale, maxZ - scale, minY, maxY, 7, 4, 15, oddLayer, primaryColor, secondaryColor);
 
             poseStack.popPose();
         }

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/SheetPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/SheetPileBlockModelMixin.java
@@ -11,6 +11,7 @@ import net.dries007.tfc.common.blockentities.SheetPileBlockEntity;
 import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.devices.SheetPileBlock;
 import net.dries007.tfc.util.Helpers;
+import net.dries007.tfc.util.Metal;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.Direction;
@@ -44,26 +45,34 @@ public abstract class SheetPileBlockModelMixin implements SimpleStaticBlockEntit
 
         for (Direction direction : Helpers.DIRECTIONS)
         {
-            if (state.getValue(DirectionPropertyBlock.getProperty(direction))) // The properties are authoritative on which sides should be rendered
-            {
+            if ((Boolean)state.getValue(DirectionPropertyBlock.getProperty(direction)))
+            { // The properties are authoritative on which sides should be rendered
                 final var stack = pile.getSheet(direction);
                 final var material = ChemicalHelper.getMaterial(stack);
                 final int primaryColor = material == null ? 0 : material.material().getMaterialARGB(0);
                 final int secondaryColor = material == null ? 0 : material.material().getMaterialARGB(1);
+                Metal metalAtPos = pile.getOrCacheMetal(direction);
 
-                sprite = textureAtlas.apply(TFGClientEventHandler.TFCMetalBlockTexturePattern);
+                boolean shouldUseTFCRender = !(metalAtPos.getId() == Metal.unknown().getId() && material != null && !material.isEmpty());
+                ResourceLocation metalResource = shouldUseTFCRender ? metalAtPos.getTextureId() : TFGClientEventHandler.TFCMetalBlockTexturePattern;
 
-                TFGClientHelpers.renderTexturedCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, SheetPileBlock.getShapeForSingleFace(direction).bounds(), primaryColor, secondaryColor);
+                sprite = (TextureAtlasSprite)textureAtlas.apply(metalResource);
+                this.renderSheet(poseStack, sprite, buffer, direction, packedLight, packedOverlay, shouldUseTFCRender, primaryColor, secondaryColor);
             }
         }
 
-        if (sprite == null)
-        {
-            // Use whatever sprite we found in the ingot pile towards the top as the particle texture
+        if (sprite == null) {
             sprite = RenderHelpers.missingTexture();
         }
 
         return sprite;
+    }
+
+    private void renderSheet(PoseStack poseStack, TextureAtlasSprite sprite, VertexConsumer buffer, Direction direction, int packedLight, int packedOverlay, boolean shouldUseTFCRender, int primaryColor, int secondaryColor) {
+        if (shouldUseTFCRender)
+            RenderHelpers.renderTexturedCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, SheetPileBlock.getShapeForSingleFace(direction).bounds());
+        else
+            TFGClientHelpers.renderTexturedCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, SheetPileBlock.getShapeForSingleFace(direction).bounds(), primaryColor, secondaryColor);
     }
 
 }

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/SheetPileBlockModelMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/tfc/SheetPileBlockModelMixin.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import su.terrafirmagreg.core.client.TFGClientEventHandler;
 import su.terrafirmagreg.core.client.TFGClientHelpers;
 
@@ -57,7 +58,7 @@ public abstract class SheetPileBlockModelMixin implements SimpleStaticBlockEntit
                 ResourceLocation metalResource = shouldUseTFCRender ? metalAtPos.getTextureId() : TFGClientEventHandler.TFCMetalBlockTexturePattern;
 
                 sprite = (TextureAtlasSprite)textureAtlas.apply(metalResource);
-                this.renderSheet(poseStack, sprite, buffer, direction, packedLight, packedOverlay, shouldUseTFCRender, primaryColor, secondaryColor);
+                this.tfg$renderSheet(poseStack, sprite, buffer, direction, packedLight, packedOverlay, shouldUseTFCRender, primaryColor, secondaryColor);
             }
         }
 
@@ -68,7 +69,8 @@ public abstract class SheetPileBlockModelMixin implements SimpleStaticBlockEntit
         return sprite;
     }
 
-    private void renderSheet(PoseStack poseStack, TextureAtlasSprite sprite, VertexConsumer buffer, Direction direction, int packedLight, int packedOverlay, boolean shouldUseTFCRender, int primaryColor, int secondaryColor) {
+    @Unique
+    private void tfg$renderSheet(PoseStack poseStack, TextureAtlasSprite sprite, VertexConsumer buffer, Direction direction, int packedLight, int packedOverlay, boolean shouldUseTFCRender, int primaryColor, int secondaryColor) {
         if (shouldUseTFCRender)
             RenderHelpers.renderTexturedCuboid(poseStack, buffer, sprite, packedLight, packedOverlay, SheetPileBlock.getShapeForSingleFace(direction).bounds());
         else


### PR DESCRIPTION
## What is the new behavior?
Welcome back gold.
TFC ingot piles will now fetch and use their corresponding TFC textures if they exist, only falling back to our current system (GTCEU material colours on top of base universal texture) if the metal texture does not exist.

## Implementation Details
Initially I checked just to see if the metal texture existed in TFC and then fell back to our base texture-based rendering if it didn't. Turns out TFC forces all metals it doesn't recognize into unknown. We thus check if the ingot pile *thinks* it's unknown, then crossreference GT's material registry - If it's 'seen as' unknown but has a material registry, we use our fallback rendering technique (previous behaviour), and otherwise it uses the TFC rendering.

## Outcome
- Ingots with valid TFC metal data AND a corresponding texture will show up as that texture in ingot piles.
- Ingots with no valid TFC metal data that still has GT Material data will use a colour tinted base universal texture (previous behaviour) to be rendered in ingot piles.
- Ingots with valid TFC metal data but NO corresponding texture will show up as a **missing texture**

## Additional Information
Before change           | After change
:-------------------------:|:-------------------------:
![Before change](https://github.com/user-attachments/assets/46d41e73-ad9c-4bb1-b7e2-1b855903b38c)|![After change](https://github.com/user-attachments/assets/6cad59ce-e9c8-4b28-b324-6c8e2a0f64b3)

Ingots pictured are:
Rose gold, Silver,
Gold, Copper, Black Steel.


![Mixed pile](https://github.com/user-attachments/assets/4ac3769e-461d-4b36-8846-068d9a5b3c01)
Mixed pile showing the difference between gold (TFC rendering) and aluminium (TFG rendering) and that they can coexist in one pile.

## Potential Compatibility Issues
After merging this all 'metals' defined through TFC data that have a pileable ingot MUST have a corresponding texture or they will start showing up as a missing texture. So far this happens for red alloy and tin alloy, which will probably have textures added soon into the base modpack repository to also fix issues such as them showing up as missing in mold tables. I find this a non-issue due to the very small number of metals we actually add as TFC-compatible, it's all mostly done on the GT side of things.