### PR TITLE
Fixed mixins

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,6 @@ repositories {
         url 'https://cursemaven.com'
         content {
             includeGroup "curse.maven"
-            excludeGroupByRegex("com\\.github.SSWTLZZ69.*")
         }
     }
     maven {
@@ -14,7 +13,6 @@ repositories {
         url 'https://api.modrinth.com/maven'
         content {
             includeGroup 'maven.modrinth'
-            excludeGroupByRegex("com\\.github.SSWTLZZ69.*")
         }
     }
     maven {
@@ -22,23 +20,16 @@ repositories {
         url "https://squiddev.cc/maven"
         content {
             includeGroup("cc.tweaked")
-            excludeGroupByRegex("com\\.github.SSWTLZZ69.*")
         }
     }
     maven {
         // location of the maven that hosts JEI files since January 2023
         name "Jared's maven"
         url "https://maven.blamejared.com"
-        content {
-            excludeGroupByRegex("com\\.github.SSWTLZZ69.*")
-        }
     }
     maven {
         name "Shedaniel maven"
         url "https://maven.shedaniel.me"
-        content {
-            excludeGroupByRegex("com\\.github.SSWTLZZ69.*")
-        }
     }
     maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
     maven {
@@ -48,7 +39,6 @@ repositories {
         content {
             includeGroup("com.simibubi.create")
             includeGroup("dev.engine-room.flywheel")
-            excludeGroupByRegex("com\\.github.SSWTLZZ69.*")
         }
     }
     maven { //GTM maven
@@ -63,13 +53,6 @@ repositories {
         url = "https://maven.firstdarkdev.xyz/snapshots"
         content {
             includeGroup("com.lowdragmc.ldlib")
-        }
-    }
-    //jitpack - needed for git releases
-    maven {
-        url "https://jitpack.io"
-        content {
-            includeGroup("com.github.SSWTLZZ69")
         }
     }
     flatDir {
@@ -118,10 +101,10 @@ dependencies {
     // Create: Vintage Improvements
     // TODO: REPLACED with github fork for now
     //implementation fg.deobf("maven.modrinth:create-vintage-improvements:1.20.1-0.2.0.3") { transitive = false }
-    implementation fg.deobf("com.github.SSWTLZZ69:Create-Vintage-Improvements:v0.3.1.0") { transitive = false }
+    implementation fg.deobf("curse.maven:vintage-improvements-ssw-edition-1255448:6493670") { transitive = false }
 
     // Greate
-    compileOnly fg.deobf("maven.modrinth:greate:0.0.39") { transitive = false }
+    compileOnly fg.deobf("maven.modrinth:greate:0.0.40") { transitive = false }
 
     // GTM
     implementation fg.deobf("com.gregtechceu.gtceu:gtceu-$minecraft_version:$gtm_version") { transitive = false }
@@ -136,7 +119,7 @@ dependencies {
     implementation fg.deobf("maven.modrinth:terrafirmacraft:3.2.14")
 
     // FirmaLife
-    implementation fg.deobf("maven.modrinth:firmalife:2.1.17")
+    implementation fg.deobf("maven.modrinth:firmalife:2.1.18")
 
     // Beneath
     implementation fg.deobf("maven.modrinth:beneath:1.0.4") { transitive = false }

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/create/ChainConveyorRendererMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/create/ChainConveyorRendererMixin.java
@@ -1,27 +1,22 @@
 package su.terrafirmagreg.core.mixins.client.create;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorBlockEntity;
 import com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorRenderer;
 import com.simibubi.create.foundation.render.RenderTypes;
-import dev.engine_room.flywheel.lib.transform.PoseTransformStack;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import su.terrafirmagreg.core.compat.create.ChainGTMaterialInterface;
-
-import java.util.Iterator;
 
 @Mixin(value = ChainConveyorRenderer.class)
 public class ChainConveyorRendererMixin {
@@ -33,8 +28,8 @@ public class ChainConveyorRendererMixin {
         tfg$tempChainTextureResource = null;
     }
 
-    @Inject(method = "renderChains(Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRenderer;renderChain(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;FFIIZ)V"), remap = false, locals = LocalCapture.CAPTURE_FAILSOFT)
-    private void tfg$renderChains(ChainConveyorBlockEntity be, PoseStack ms, MultiBufferSource buffer, int light, int overlay, CallbackInfo ci, float time, float animation, Iterator var8, BlockPos blockPos, ChainConveyorBlockEntity.ConnectionStats stats, Vec3 diff, double yaw, double pitch, Level level, BlockPos tilePos, Vec3 startOffset, PoseTransformStack chain, int light1, int light2, boolean far)
+    @Inject(method = "renderChains(Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRenderer;renderChain(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;FFIIZ)V"), remap = false)
+    private void tfg$renderChains(ChainConveyorBlockEntity be, PoseStack ms, MultiBufferSource buffer, int light, int overlay, CallbackInfo ci, @Local(ordinal = 0) BlockPos blockPos)
     {
         ChainGTMaterialInterface cgtbe = (ChainGTMaterialInterface) be;
         String matPath = cgtbe.getConnectionMaterial(blockPos).getResourceLocation().getPath();
@@ -48,7 +43,7 @@ public class ChainConveyorRendererMixin {
         tfg$tempChainTextureResource = null;
     }
 
-    @ModifyArg(method = "renderChain(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;FFIIZ)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/MultiBufferSource;getBuffer(Lnet/minecraft/client/renderer/RenderType;)Lcom/mojang/blaze3d/vertex/VertexConsumer;"), remap = false)
+    @ModifyArg(method = "renderChain(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;FFIIZ)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/MultiBufferSource;getBuffer(Lnet/minecraft/client/renderer/RenderType;)Lcom/mojang/blaze3d/vertex/VertexConsumer;"))
     private static RenderType tfg$renderChain$getBuffer(RenderType pRenderType)
     {
         if(ResourceLocation.isValidResourceLocation(tfg$tempChainTextureResource.toString()))

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/create/ChainConveyorBlockMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/create/ChainConveyorBlockMixin.java
@@ -22,13 +22,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import su.terrafirmagreg.core.common.data.TFGTags;
 import su.terrafirmagreg.core.compat.create.ChainGTMaterialInterface;
 
-@Mixin(value = ChainConveyorBlock.class, remap = false)
+@Mixin(value = ChainConveyorBlock.class)
 public abstract class ChainConveyorBlockMixin extends KineticBlock implements IBE<ChainConveyorBlockEntity>, IHaveBigOutline {
     public ChainConveyorBlockMixin(Properties properties) {
         super(properties);
     }
 
-    @Inject(method = "use(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/phys/BlockHitResult;)Lnet/minecraft/world/InteractionResult;", at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "use", at = @At("HEAD"), cancellable = true)
     private void tfg$use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHit, CallbackInfoReturnable<InteractionResult> cir)
     {
         if (!pLevel.isClientSide() && pPlayer != null && pPlayer.getItemInHand(pHand).is(TFGTags.Items.Chains))

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/create/ChainConveyorConnectionPacketMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/create/ChainConveyorConnectionPacketMixin.java
@@ -3,21 +3,22 @@ package su.terrafirmagreg.core.mixins.common.create;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorBlockEntity;
 import com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorConnectionPacket;
 import com.simibubi.create.foundation.networking.BlockEntityConfigurationPacket;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import su.terrafirmagreg.core.compat.create.ChainGTMaterialInterface;
 
-@Mixin(value = ChainConveyorConnectionPacket.class, remap = false)
+@Mixin(value = ChainConveyorConnectionPacket.class)
 public abstract class ChainConveyorConnectionPacketMixin extends BlockEntityConfigurationPacket<ChainConveyorBlockEntity> {
     @Shadow private ItemStack chain;
     @Shadow private BlockPos targetPos;
@@ -26,8 +27,8 @@ public abstract class ChainConveyorConnectionPacketMixin extends BlockEntityConf
         super(pos);
     }
 
-    @Redirect( method = "applySettings(Lnet/minecraft/server/level/ServerPlayer;Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;)V", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;addConnectionTo(Lnet/minecraft/core/BlockPos;)Z"), remap = false)
-    private boolean tfg$applySettings$addConnectionTo(ChainConveyorBlockEntity instance, BlockPos target)
+    @WrapOperation( method = "applySettings(Lnet/minecraft/server/level/ServerPlayer;Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;)V", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;addConnectionTo(Lnet/minecraft/core/BlockPos;)Z"), remap = false)
+    private boolean tfg$applySettings$addConnectionTo(ChainConveyorBlockEntity instance, BlockPos target, Operation<Boolean> original)
     {
         MaterialStack chainMatStack = ChemicalHelper.getMaterial(chain.getItem());
         if (chainMatStack != null )
@@ -36,17 +37,16 @@ public abstract class ChainConveyorConnectionPacketMixin extends BlockEntityConf
             ChainGTMaterialInterface cgtinstance = (ChainGTMaterialInterface) instance;
             cgtinstance.addConnectionMaterial(target, chainMat);
         }
-        return instance.addConnectionTo(target);
+        return original.call(instance, target);
     }
 
 
-    @Redirect( method = "applySettings(Lnet/minecraft/server/level/ServerPlayer;Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;placeItemBackInInventory(Lnet/minecraft/world/item/ItemStack;)V"), remap = false)
-    private void tfg$applySettings$placeItemBackInInventory(Inventory instance, ItemStack pStack, ServerPlayer player, ChainConveyorBlockEntity be)
+    @ModifyArg( method = "applySettings(Lnet/minecraft/server/level/ServerPlayer;Lcom/simibubi/create/content/kinetics/chainConveyor/ChainConveyorBlockEntity;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;placeItemBackInInventory(Lnet/minecraft/world/item/ItemStack;)V"))
+    private ItemStack tfg$applySettings$placeItemBackInInventory(ItemStack pStack, @Local(ordinal = 0, argsOnly = true) ChainConveyorBlockEntity be)
     {
         BlockPos localPos = targetPos.subtract(be.getBlockPos());
         ChainGTMaterialInterface be_GTMaterialInterface = (ChainGTMaterialInterface) be;
         Item chainItem = be_GTMaterialInterface.getConnectionChainItem(localPos);
-        System.out.println(chainItem.toString());
-        instance.placeItemBackInInventory(new ItemStack(chainItem, pStack.getCount()));
+        return new ItemStack(chainItem, pStack.getCount());
     }
 }


### PR DESCRIPTION
## What is the new behavior?
This commit fixes the Critical injection failure error that was occurring in my build when deployed to the actual modpack environment.

## Implementation Details
The issue was that I set the inject methods to `remap=false` when they were injecting into an overridden vanilla minecraft method, when due to obfuscation this really should have been not the case. Some more dangerous mixins (locals, for example) have also been changed to use mixinextras features.

Additionally changes the temporary jitpack dependency for the Vintage Improvements fork to now use the correct, proper version which was later deployed to curse maven.