### PR TITLE
Fix mining hammer collapse bug

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ToolHelperMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ToolHelperMixin.java
@@ -83,7 +83,7 @@ public abstract class ToolHelperMixin {
                 for (int y = (row == 0 ? 0 : row * 2 - 1); y >= (row == 0 ? 0 : -1); y--) {
                     for (int x = 0; x <= layer; x++) {
                         for (int z = -column; z <= column; z++) {
-                            if (!(x == 0 && y == 0 && z == 0)) {
+                            if (!(x == 0 && y <= 0 && z == 0)) {
                                 BlockPos pos = blockHit.getBlockPos().offset(
                                         isX ? (isNegative ? x : -x) : (isNegative ? z : -z), y,
                                         isX ? (isNegative ? z : -z) : (isNegative ? x : -x));
@@ -92,6 +92,14 @@ public abstract class ToolHelperMixin {
                                 }
                             }
                         }
+                    }
+                }
+                // Block under targeted block must be the last one added to prevent collapse
+                // Targeted block is broken after all blocks in validPositions
+                if (row > 0) {
+                    BlockPos pos = blockHit.getBlockPos().offset(0, -1, 0);
+                    if (function.apply(stack, world, player, pos, new UseOnContext(player.level(), player, player.getUsedItemHand(), stack, blockHit))) {
+                        validPositions.add(pos);
                     }
                 }
             }


### PR DESCRIPTION
Fixes issue TerraFirmaGreg-Team/Modpack-Modern#1112 where the mining hammer could cause a collapse in certain circumstances when it shouldn't have.

Fix involved adding the block under the targeted block to the AoE set last. This prevents the targeted block from triggering a collapse, because the targeted block is always broken last and is handled outside of iterateAoE() so its order cannot be changed.