### PR TITLE
fixed registrate repo issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 repositories {
     maven {
         name "Tterrag"
-        url  "https://maven.tterrag.com/"
+        url  "https://modmaven.dev/"
         content {
             includeGroup("com.jozufozu.flywheel")
             includeGroup("com.tterrag.registrate")


### PR DESCRIPTION
Registrate on the repo  (https://maven.tterrag.com/) has worked but
Registrate was removed from there breaking gradle,
we have to change it in the gradle to 
(https://modmaven.dev/)