### PR TITLE
enable FTB quests to summon patchouli GUI

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -136,6 +136,7 @@ dependencies {
     // FTB
     implementation fg.deobf("curse.maven:ftb-teams-forge-404468:6130786") { transitive = false }
     implementation fg.deobf("curse.maven:ftb-library-forge-404465:6164053") { transitive = false }
+    implementation fg.deobf("curse.maven:ftb-quests-forge-289412:6431737") { transitive = false }
 
     // Jade
     implementation fg.deobf("curse.maven:jade-324717:6271651")

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/ftb/QuestScreenMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/ftb/QuestScreenMixin.java
@@ -1,0 +1,70 @@
+package su.terrafirmagreg.core.mixins.client.ftb;
+
+import dev.ftb.mods.ftbquests.client.gui.quests.QuestScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import vazkii.patchouli.api.PatchouliAPI;
+
+
+@OnlyIn(Dist.CLIENT)
+@Mixin(value = QuestScreen.class, remap = false)
+public abstract class QuestScreenMixin {
+    private static final String GUIDE_RL = "tfc:field_guide";
+
+    @Inject(method = "handleClick", at = @At(value = "HEAD"), cancellable = true)
+    private void catchTfcFieldGuidePaths(String scheme, String path, CallbackInfoReturnable<Boolean> cir) {
+        // Skip catch if button pressed isn't related to guide books
+        if (!(scheme.equals("guide")) || path.isBlank()) {
+            return;
+        }
+
+        // click is handled, return true on inject exit
+        cir.setReturnValue(true);
+        String[] bookArgs = path.split(" ");
+
+        try {
+            // Validation
+            if (bookArgs.length > 3) {
+                throw new IllegalArgumentException("more than 3 arguments");
+            } else if (!(bookArgs[0].equals(GUIDE_RL))) {
+                throw new IllegalArgumentException("invalid field guide resource location");
+            } else if (bookArgs.length > 1 && ResourceLocation.tryParse(bookArgs[1]) == null) {
+                throw new IllegalArgumentException("invalid entry resource location");
+            } else if (bookArgs.length == 3 && !StringUtils.isNumeric(bookArgs[2])) {
+                throw new IllegalArgumentException("invalid page number");
+            }
+
+            //open-patchouli-book command syntax: /... targets book entry (optional) page
+            ResourceLocation bookAddress = ResourceLocation.tryParse(GUIDE_RL);
+            if (bookArgs.length == 1) {
+                PatchouliAPI.get().openBookGUI(bookAddress);
+            } else {
+                ResourceLocation entryAddress = ResourceLocation.tryParse(bookArgs[1]);
+                int pageNumber = (bookArgs.length != 3) ? 0 : Integer.parseInt(bookArgs[2]);
+                PatchouliAPI.get().openBookEntry(bookAddress, entryAddress, pageNumber);
+            }
+
+        } catch (Exception e) {
+            String failureMessage = "failed to open guide, invalid path:" + path + "\n" + "reason: " + e;
+            chatMessage(failureMessage);
+        }
+    }
+
+    @Unique
+    private void chatMessage(String message) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null) {
+            player.sendSystemMessage(Component.literal(message));
+        }
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -88,6 +88,7 @@
   ],
   "client": [
     "client.ftb.ClientTeamManagerImplMixin",
+    "client.ftb.QuestScreenMixin",
     "client.gtceu.ISurfaceRockRendererAccessor",
     "client.minecraft.CreateWorldScreenMixin",
     "client.tfc.DoubleIngotPileBlockModelMixin",


### PR DESCRIPTION
## What is the new behavior?
fixes [#854](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/854)

## Implementation Details
Adds behavior functionally identical to Patchouli's `/open-patchouli-book` command with exactly the same syntax.
In the `Guide Page` field of a quest, type any of the following:

1. `tfc:field_guide` 
this opens the field guide to whatever page was last opened.
2.  `tfc:field_guide <entry resource_location>`
this opens the field guide to the first page of the provided entry.
3.  `tfc:field_guide <entry resource_location> <page number>`
this opens the field guide to the specified page of the provided entry.

## Outcome
We can now link specific field guide entries to quests, which should 1) increase cohesiveness between the quest system and TFC, and 2) better inform players of game functionality

## Additional Information
[video demo](https://discord.com/channels/400913133620822016/1378754174983868416/1400707815340900492)

## Potential Compatibility Issues
None.