### PR TITLE
Fix grappling hook ladder death bug

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -161,6 +161,10 @@ dependencies {
     // Simply Stacked Dimensions
     implementation fg.deobf("curse.maven:simply-stacked-dimensions-523416:5562948") { transitive = false }
 
+    // Grappling Hook -- needless dependencies are dumb
+    implementation fg.deobf("curse.maven:cloth-config-348521:5729105")
+    implementation fg.deobf("curse.maven:grappling-hook-mod-reforged-1166811:6028357") { transitive = false }
+
     // Hang Glider
     implementation fg.deobf("maven.modrinth:puzzles-lib:${puzzleslib_version}")
     implementation fg.deobf("maven.modrinth:hang-glider:${hangglider_version}")

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/AirFrictionControllerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/AirFrictionControllerMixin.java
@@ -1,0 +1,31 @@
+package su.terrafirmagreg.core.mixins.common.grappling_hook;
+
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.yyon.grapplinghook.controllers.AirfrictionController;
+import com.yyon.grapplinghook.controllers.GrappleController;
+import com.yyon.grapplinghook.utils.GrappleCustomization;
+import com.yyon.grapplinghook.utils.Vec;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = AirfrictionController.class, remap = false)
+public class AirFrictionControllerMixin extends GrappleController {
+
+    public AirFrictionControllerMixin(int grapplehookEntityId, int entityId, Level world, Vec pos, int controllerid, GrappleCustomization custom) {
+        super(grapplehookEntityId, entityId, world, pos, controllerid, custom);
+    }
+
+    @Inject(method = "updatePlayerPos", at = @At(value = "NEW", target = "(DDD)Lcom/yyon/grapplinghook/utils/Vec;", ordinal = 0), cancellable = true)
+    private void tfg$injectLadderFix(CallbackInfo ci, @Local Entity entity) {
+        if (entity instanceof LivingEntity living && living.onClimbable()) {
+            this.unattach();
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/AirFrictionControllerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/AirFrictionControllerMixin.java
@@ -1,3 +1,8 @@
+/*
+ * This file includes code from Grappling Hook - Reforged (https://www.curseforge.com/minecraft/mc-mods/grappling-hook-mod-reforged)
+ * Copyright (c) 2024 Chummycho
+ * Licensed under the GPLv3 License
+ */
 package su.terrafirmagreg.core.mixins.common.grappling_hook;
 
 

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/GrappleControllerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/GrappleControllerMixin.java
@@ -1,3 +1,8 @@
+/*
+ * This file includes code from Grappling Hook - Reforged (https://www.curseforge.com/minecraft/mc-mods/grappling-hook-mod-reforged)
+ * Copyright (c) 2024 Chummycho
+ * Licensed under the GPLv3 License
+ */
 package su.terrafirmagreg.core.mixins.common.grappling_hook;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/GrappleControllerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/grappling_hook/GrappleControllerMixin.java
@@ -1,0 +1,25 @@
+package su.terrafirmagreg.core.mixins.common.grappling_hook;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.yyon.grapplinghook.controllers.GrappleController;
+import com.yyon.grapplinghook.utils.Vec;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = GrappleController.class, remap = false)
+public class GrappleControllerMixin {
+    @Shadow
+    public Vec motion;
+
+    @Shadow
+    public Entity entity;
+
+    @WrapOperation(method = "doubleJump", at = @At(value = "INVOKE", target = "Lcom/yyon/grapplinghook/utils/Vec;setMotion(Lnet/minecraft/world/entity/Entity;)V"))
+    private void tfg$resetFallDistanceOnDoubleJump(Vec instance, Entity e, Operation<Void> original) {
+        this.motion.setMotion(e);
+        e.resetFallDistance();
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -32,6 +32,8 @@
     "common.firmalife.HydroponicPlanterBlockEntityMixin",
     "common.firmalife.MixinGreenhousePortBlock",
     "common.flywheel.AnimatedBlazeBurnerMixin",
+    "common.grappling_hook.AirFrictionControllerMixin",
+    "common.grappling_hook.GrappleControllerMixin",
     "common.greate.TieredCrushingCategoryMixin",
     "common.greate.TieredCrushingRecipeMixin",
     "common.greate.TieredMillingCategoryMixin",


### PR DESCRIPTION
## What is the new behavior?
Fixes [#1647](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/1647) on our side while my [PR for Grappling Hook Reforged](https://github.com/alexhowell610/Grappling-Hook-Mod-Reforged/pull/1) is reviewed

## Implementation Details
I copied this fix from [a PR from the original Grappling Hook mod](https://github.com/yyon/grapplemod/pull/123). It adds an additional ladder check as well as resets fall distance on grapple release.

## Outcome
Grappling hooks no longer kill you if you jump from one onto a ladder.

## Additional Information
This apparently fixes other issues with how grappling hooks and gliders interact according to [#123](https://github.com/yyon/grapplemod/pull/123), so that's good?

## Potential Compatibility Issues
If my PR gets accepted by the grapple mod author then this fix will become redundant and will need to be removed.
