### PR TITLE
GTUtil.canSeeSunClearly rain fix mixin

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
@@ -1,0 +1,51 @@
+package su.terrafirmagreg.core.mixins.common.gtceu;
+
+import com.gregtechceu.gtceu.utils.GTUtil;
+import net.dries007.tfc.util.EnvironmentHelpers;
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import su.terrafirmagreg.core.TFGCore;
+
+@Mixin(value = GTUtil.class, remap = false)
+public abstract class GTUtilMixin {
+
+    /**
+     * @author FiNiTe
+     * @reason i think replacing it fully just makes sense
+     * <br>
+     * the EnvironmentHelpers thing I found from <a href="https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.20.x/src/main/java/net/dries007/tfc/mixin/LevelMixin.java">https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.20.x/src/main/java/net/dries007/tfc/mixin/LevelMixin.java</a>
+     */
+    @Overwrite
+    public static boolean canSeeSunClearly(Level world, BlockPos blockPos) {
+        //todo: i heard theres some ad astra weather stuff??
+        if (!world.canSeeSky(blockPos.above())) {
+            return false;
+        } else {
+            Biome biome = (Biome)world.getBiome(blockPos.above()).value();
+            //for tfc overworld: EnvironmentHelpers.isRainingOrSnowing(world,blockPos) instead of world.isRaining()
+            //just incase I left it how it was before for other dimensions
+            if(world.dimension()==Level.OVERWORLD) {
+                return world.isDay() && !EnvironmentHelpers.isRainingOrSnowing(world,blockPos);
+            } else if (!world.isRaining() || !biome.warmEnoughToRain(blockPos.above()) && !biome.coldEnoughToSnow(blockPos.above())) {
+                if (world.getBiome(blockPos.above()).is(BiomeTags.IS_END)) {
+                    return false;
+                } else {
+                    return world.isDay();
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+
+    //i realised this doesnt give me coord
+    /*@Redirect(method = "canSeeSunClearly", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;isRaining()Z"), remap = false)
+    private static boolean tfg$canSeeSunClearly$isRaining(Level instance) {
+        TFGCore.LOGGER.info("bananaphone");
+        return false;
+    }*/
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
@@ -41,11 +41,4 @@ public abstract class GTUtilMixin {
             }
         }
     }
-
-    //i realised this doesnt give me coord
-    /*@Redirect(method = "canSeeSunClearly", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;isRaining()Z"), remap = false)
-    private static boolean tfg$canSeeSunClearly$isRaining(Level instance) {
-        TFGCore.LOGGER.info("bananaphone");
-        return false;
-    }*/
 }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
@@ -15,7 +15,7 @@ public abstract class GTUtilMixin {
 
     /**
      * @author FiNiTe
-     * @reason i think replacing it fully just makes sense
+     * @reason makes GT solar machines understand TFC's rain mechanics
      * <br>
      * the EnvironmentHelpers thing I found from <a href="https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.20.x/src/main/java/net/dries007/tfc/mixin/LevelMixin.java">https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1.20.x/src/main/java/net/dries007/tfc/mixin/LevelMixin.java</a>
      */

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
@@ -31,11 +31,7 @@ public abstract class GTUtilMixin {
             if(world.dimension()==Level.OVERWORLD) {
                 return world.isDay() && !EnvironmentHelpers.isRainingOrSnowing(world,blockPos);
             } else if (!world.isRaining() || !biome.warmEnoughToRain(blockPos.above()) && !biome.coldEnoughToSnow(blockPos.above())) {
-                if (world.getBiome(blockPos.above()).is(BiomeTags.IS_END)) {
-                    return false;
-                } else {
-                    return world.isDay();
-                }
+                return world.isDay();
             } else {
                 return false;
             }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTUtilMixin.java
@@ -22,15 +22,16 @@ public abstract class GTUtilMixin {
     @Overwrite
     public static boolean canSeeSunClearly(Level world, BlockPos blockPos) {
         //todo: i heard theres some ad astra weather stuff??
-        if (!world.canSeeSky(blockPos.above())) {
+        BlockPos bLockPosAbove = blockPos.above();
+        if (!world.canSeeSky(bLockPosAbove)) {
             return false;
         } else {
-            Biome biome = (Biome)world.getBiome(blockPos.above()).value();
+            Biome biome = (Biome)world.getBiome(bLockPosAbove).value();
             //for tfc overworld: EnvironmentHelpers.isRainingOrSnowing(world,blockPos) instead of world.isRaining()
             //just incase I left it how it was before for other dimensions
             if(world.dimension()==Level.OVERWORLD) {
                 return world.isDay() && !EnvironmentHelpers.isRainingOrSnowing(world,blockPos);
-            } else if (!world.isRaining() || !biome.warmEnoughToRain(blockPos.above()) && !biome.coldEnoughToSnow(blockPos.above())) {
+            } else if (!world.isRaining() || !biome.warmEnoughToRain(bLockPosAbove) && !biome.coldEnoughToSnow(bLockPosAbove)) {
                 return world.isDay();
             } else {
                 return false;

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -48,6 +48,7 @@
     "common.gtceu.ModelManagerMixin",
     "common.gtceu.NotifiableItemStackHandlerMixin",
     "common.gtceu.SteamBoilerMachineMixin",
+    "common.gtceu.GTUtilMixin",
     "common.gtceu.SurfaceRockBlockMixin",
     "common.gtceu.TagPrefixItemMixin",
     "common.gtceu.ToolHelperMixin",


### PR DESCRIPTION
## What is the new behavior?
canSeeSunClearly, used in checking if solar boilers should be working, sometimes thinks the sun isnt clearly visible due to GT assuming that if rain is happening somewhere, its happening everywhere where rain can happen (which isn't true in TFC)

## Potential Compatibility Issues
shouldnt be any

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
finite