### PR TITLE
using tags for minecart fuels

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/MinecartFurnaceMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/MinecartFurnaceMixin.java
@@ -1,0 +1,21 @@
+package su.terrafirmagreg.core.mixins.common.minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.dries007.tfc.common.TFCTags;
+import net.minecraft.world.entity.vehicle.MinecartFurnace;
+import net.minecraft.world.item.crafting.Ingredient;
+
+@Mixin(MinecartFurnace.class)
+public abstract class MinecartFurnaceMixin {
+
+    @Shadow
+    @Mutable
+    private static Ingredient INGREDIENT;
+
+    static {
+        INGREDIENT = Ingredient.of(TFCTags.Items.FORGE_FUEL);
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -72,6 +72,7 @@
     "common.minecraft.HeightmapMixin",
     "common.minecraft.IBlockLootSubProviderAccessor",
     "common.minecraft.IUseOnContextInvoker",
+    "common.minecraft.MinecartFurnaceMixin",
     "common.minecraft.MonsterMixin",
     "common.minecraft.MushroomBlockMixin",
     "common.minecraft.NetherPortalBlockMixin",


### PR DESCRIPTION
## What is the new behavior?
Allow `minecart_furance` to use any item tagged as `tfc:forge_fuel` as its fuel source. Vanilla implementation is a hard-coded list of Charcoal and Coal