### PR TITLE
Cancel println statement from Sandworms mod

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/sandworms/WormSignHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/sandworms/WormSignHandlerMixin.java
@@ -1,0 +1,17 @@
+package su.terrafirmagreg.core.mixins.common.sandworms;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraftforge.event.TickEvent;
+
+@Pseudo
+@Mixin(targets = "net.jelly.sandworm_mod.event.WormSignHandler")
+public class WormSignHandlerMixin {
+    @Redirect(method = "tickWS", at = @At(value = "INVOKE", target = "Ljava/io/PrintStream;println(I)V"))
+    private static void tfg$tickWS(TickEvent.PlayerTickEvent event, CallbackInfo ci) {
+    } // Effectively cancel the println
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -81,6 +81,7 @@
     "common.minecraft.MushroomBlockMixin",
     "common.minecraft.ServerAdvancementManagerMixin",
     "common.minecraft.ServerLifecycleHooksMixin",
+    "common.sandworms.WormSignHandlerMixin",
     "common.simply_stacked_dimensions.TeleportHandlerMixin",
     "common.species.BirtMixin",
     "common.species.GooberMixin",


### PR DESCRIPTION

## What is the new behavior?
Effectively cancel a println statement from the sandworms mod without having to depend on the mod itself

## Implementation Details
Annotating the Mixin class with `@Pseudo` which allows us to target classes which might not be present at compile time, but are at runtime, for this we use the fully qualified class name to target said class.
## Outcome
Removes the useless System.out.println call made by the Sandworms mod

## Potential Compatibility Issues
None really, the `@Pseudo` annotation skips the mixin class if it is not present at run time, which is useful for the dev environment