### PR TITLE
FirmaLife Food Shelf Round Creation Date of Food when taken off the shelf

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/firmalife/MixinFoodShelfBlockEntity.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/firmalife/MixinFoodShelfBlockEntity.java
@@ -1,0 +1,70 @@
+package su.terrafirmagreg.core.mixins.common.firmalife;
+
+
+import com.eerussianguy.firmalife.common.blockentities.ClimateReceiver;
+import com.eerussianguy.firmalife.common.blockentities.FoodShelfBlockEntity;
+import net.dries007.tfc.common.blockentities.InventoryBlockEntity;
+import net.dries007.tfc.common.capabilities.food.FoodCapability;
+import net.dries007.tfc.common.capabilities.food.FoodTrait;
+import net.dries007.tfc.util.Helpers;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FoodShelfBlockEntity.class)
+public abstract class MixinFoodShelfBlockEntity extends InventoryBlockEntity<ItemStackHandler> implements ClimateReceiver {
+
+    @Shadow private boolean climateValid;
+
+    @Shadow protected abstract void updatePreservation(boolean climateValid);
+    @Shadow protected abstract FoodTrait getFoodTrait();
+
+    protected MixinFoodShelfBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state,
+                                        InventoryFactory<ItemStackHandler> inventoryFactory,
+                                        Component defaultName) {
+        super(type, pos, state, inventoryFactory, defaultName);
+    }
+
+    @Inject(method = "use", at = @At("HEAD"), cancellable = true,remap = false)
+    private void tfg$use(Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
+        assert level != null;
+        var res = InteractionResult.PASS;
+        final ItemStack held = player.getItemInHand(hand);
+        if (!held.isEmpty() && isItemValid(0, held))
+        {
+            if (climateValid)
+            {
+                FoodCapability.applyTrait(held, ((FoodShelfBlockEntity)(Object)  this).getFoodTrait());
+            }
+            player.setItemInHand(hand, Helpers.mergeInsertStack(inventory, 0, held));
+
+            FoodCapability.removeTrait(player.getItemInHand(hand),getFoodTrait());
+            res = InteractionResult.sidedSuccess(level.isClientSide);
+        }
+        else if (held.isEmpty())
+        {
+            ItemStack stack = inventory.extractItem(0, player.isShiftKeyDown() ? Integer.MAX_VALUE : 1, false);
+            if (stack.isEmpty()) cir.setReturnValue(InteractionResult.PASS);
+            FoodCapability.removeTrait(stack, getFoodTrait());
+            FoodCapability.setCreationDate(stack,FoodCapability.getRoundedCreationDate());
+            ItemHandlerHelper.giveItemToPlayer(player, stack);
+            res = InteractionResult.sidedSuccess(level.isClientSide);
+        }
+        updatePreservation(climateValid);
+        markForSync();
+        cir.setReturnValue(res);
+    }
+}
+

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -41,6 +41,7 @@
     "common.create_additions.LiquidBlazeBurnerBlockEntityMixin",
     "common.emi.ItemEmiStackMixin",
     "common.firmalife.HydroponicPlanterBlockEntityMixin",
+    "common.firmalife.MixinFoodShelfBlockEntity",
     "common.firmalife.MixinGreenhousePortBlock",
     "common.flywheel.AnimatedBlazeBurnerMixin",
     "common.grappling_hook.AirFrictionControllerMixin",


### PR DESCRIPTION
## What is the new behavior?
 Food Shelf Round Creation Date of Food taken off the shelf,  food now stacks when removed instead of having expiration date being a few minutes apart 
## Implementation Details
Mixin into firmalife FoodShelfBlockEntity

## Outcome

## Additional Information
_This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of._

## Potential Compatibility Issues
Might lose some time on food if it gets rounded to much


Discord: Aidie8
