### PR TITLE
Switch ae2 to Cosmic Frontiert fork

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -131,7 +131,7 @@ dependencies {
     // AE2
     implementation fg.deobf("curse.maven:guideme-1173950:7013686")
     implementation fg.deobf(jarJar("appeng:appliedenergistics2-forge:$ae2_version")) {
-        jarJar.ranged(it, "[$ae2_version,)
+        jarJar.ranged(it, "[$ae2_version,)")
     }
 
     // ComputerCraft

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -130,7 +130,9 @@ dependencies {
 
     // AE2
     implementation fg.deobf("curse.maven:guideme-1173950:7013686")
-    implementation fg.deobf("curse.maven:applied-energistics-2-223794:6852919")
+    implementation fg.deobf(jarJar("appeng:appliedenergistics2-forge:$ae2_version")) {
+        jarJar.ranged(it, "[$ae2_version,)
+    }
 
     // ComputerCraft
     implementation fg.deobf("cc.tweaked:cc-tweaked-1.20.1-core-api:${cc_tweaked_version}")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,6 +44,7 @@ repositories {
         url = 'https://maven.gtceu.com'
         content {
             includeGroup 'com.gregtechceu.gtceu'
+            includeGroup 'appeng'
         }
     }
     maven { // LDLib, Shimmer

--- a/gradle.properties
+++ b/gradle.properties
@@ -67,3 +67,4 @@ cc_tweaked_version = 1.111.0
 ad_astra_version = 1.15.20
 puzzleslib_version = v8.1.32-1.20.1-Forge
 hangglider_version = v8.0.1-1.20.1-Forge
+ae2_version=15.4.7-cosmolite.14


### PR DESCRIPTION
## What is the new behavior?
Cooler and better ae2

## Implementation Details
Switch repo to the gtceu one and change dependency version

## Outcome
Feature: more cool features i guess???

## Additional Information
Will now need to use the -all.jar when building

## Potential Compatibility Issues
Very low chance of breaking addons, currently only pcc is affected, but that's being taken care of by @Pyritie 