### PR TITLE
Release: 0.7.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ java_version = 17
 
 # Mod Information
 # HIGHLY RECOMMEND complying with SemVer for mod_version: https://semver.org/
-mod_version = 0.7.18
+mod_version = 0.7.19
 mod_package = su.terrafirmagreg
 mod_id = tfg
 mod_name = TerraFirmaGreg-Core

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/beneath/NetherSpikesFeatureMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/beneath/NetherSpikesFeatureMixin.java
@@ -1,0 +1,38 @@
+package su.terrafirmagreg.core.mixins.common.beneath;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import com.eerussianguy.beneath.world.feature.NetherSpikesFeature;
+
+import net.dries007.tfc.common.blocks.TFCBlocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluids;
+
+import su.terrafirmagreg.core.common.data.TFGBlockProperties;
+
+@Mixin(value = NetherSpikesFeature.class, remap = false)
+public class NetherSpikesFeatureMixin {
+
+	/**
+	 * @author Pyritie
+	 * @reason Change the normal rock spike block fluid property to the TFG one to support more fluids
+	 */
+	@Overwrite
+	protected void replaceBlock(WorldGenLevel level, BlockPos pos, BlockState state) {
+		final Block block = level.getBlockState(pos).getBlock();
+		if (block == Blocks.AIR) {
+			level.setBlock(pos, state, 3);
+		} else if (block != Blocks.WATER && block != TFCBlocks.RIVER_WATER.get()) {
+			if (block == Blocks.LAVA) {
+				level.setBlock(pos, state.setValue(TFGBlockProperties.SPACE_WATER_AND_LAVA, TFGBlockProperties.SPACE_WATER_AND_LAVA.keyFor(Fluids.LAVA)), 3);
+			}
+		} else {
+			level.setBlock(pos, state.setValue(TFGBlockProperties.SPACE_WATER_AND_LAVA, TFGBlockProperties.SPACE_WATER_AND_LAVA.keyFor(Fluids.WATER)), 3);
+		}
+	}
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -19,6 +19,7 @@
     "common.ae2.InitP2PAttunementsMixin",
     "common.beneath.BurpingFlowerBlockMixin",
     "common.beneath.LavaAqueductBlockMixin",
+    "common.beneath.NetherSpikesFeatureMixin",
     "common.beneath.PortalUtilMixin",
     "common.create.BasinBlockEntityMixin",
     "common.create.BasinCategoryMixin",


### PR DESCRIPTION
Should fix the rare issue with the rock spikes crashing in the beneath.

This is a branch off of `main` and not `dev`, so it doesn't have any of the recent ae2 fork that `dev` does. This might affect your build scripts?