### PR TITLE
fix wireless terminal..

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ae2/WirelessTerminalMenuHostMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ae2/WirelessTerminalMenuHostMixin.java
@@ -36,7 +36,7 @@ public abstract class WirelessTerminalMenuHostMixin extends ItemMenuHost {
     @Redirect(method = "checkWirelessRange", at = @At(value = "INVOKE", target = "Lappeng/helpers/WirelessTerminalMenuHost;rangeCheck()Z"))
     private boolean tfg$checkWirelessRange(WirelessTerminalMenuHost instance) {
         return (this.getUpgrades().isInstalled(TFGItems.WIRELESS_CARD.get()) && this.myWap != null)
-                || !instance.rangeCheck();
+                || instance.rangeCheck();
     }
 
     /**


### PR DESCRIPTION
## What is the new behavior?
fix the wireless terminal only opening when out of range of the access point and not having a wireless card

## Implementation Details
don't invert the range check, as the method we redirect already does that
## Outcome
fix the terminal not opening..