### PR TITLE
Updated particle emitters

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
@@ -52,7 +52,6 @@ public class TFGBlockEntities {
                     () -> BlockEntityType.Builder.of(ReflectorBlockEntity::new, TFGBlocks.REFLECTOR_BLOCK.get())
                             .build(null));
 
-
     // Shared particle emitter ticker entity.
     public static final RegistryObject<BlockEntityType<TickerBlockEntity>> TICKER_ENTITY = BLOCK_ENTITIES
             .register("particle_emitter", () -> {

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
@@ -1,8 +1,12 @@
 package su.terrafirmagreg.core.common.data;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.eerussianguy.firmalife.common.blocks.FLBlocks;
 import com.eerussianguy.firmalife.common.blocks.greenhouse.Greenhouse;
 
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -12,6 +16,10 @@ import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.blockentity.GTGreenhousePortBlockEntity;
 import su.terrafirmagreg.core.common.data.blockentity.LargeNestBoxBlockEntity;
 import su.terrafirmagreg.core.common.data.blockentity.ReflectorBlockEntity;
+import su.terrafirmagreg.core.common.data.blockentity.TickerBlockEntity;
+import su.terrafirmagreg.core.compat.kjs.GTActiveParticleBuilder;
+import su.terrafirmagreg.core.compat.kjs.ParticleEmitterBlockBuilder;
+import su.terrafirmagreg.core.compat.kjs.ParticleEmitterDecorationBlockBuilder;
 
 public class TFGBlockEntities {
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister
@@ -44,4 +52,12 @@ public class TFGBlockEntities {
                     () -> BlockEntityType.Builder.of(ReflectorBlockEntity::new, TFGBlocks.REFLECTOR_BLOCK.get())
                             .build(null));
 
+    public static final RegistryObject<BlockEntityType<TickerBlockEntity>> TICKER_ENTITY = BLOCK_ENTITIES
+            .register("particle_emitter", () -> {
+                List<Block> blocks = new ArrayList<>();
+                blocks.addAll(ParticleEmitterBlockBuilder.REGISTERED_BLOCKS);
+                blocks.addAll(ParticleEmitterDecorationBlockBuilder.REGISTERED_BLOCKS);
+                blocks.addAll(GTActiveParticleBuilder.REGISTERED_BLOCKS);
+                return BlockEntityType.Builder.of(TickerBlockEntity::new, blocks.toArray(Block[]::new)).build(null);
+            });
 }

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
@@ -52,6 +52,8 @@ public class TFGBlockEntities {
                     () -> BlockEntityType.Builder.of(ReflectorBlockEntity::new, TFGBlocks.REFLECTOR_BLOCK.get())
                             .build(null));
 
+
+    // Shared particle emitter ticker entity.
     public static final RegistryObject<BlockEntityType<TickerBlockEntity>> TICKER_ENTITY = BLOCK_ENTITIES
             .register("particle_emitter", () -> {
                 List<Block> blocks = new ArrayList<>();

--- a/src/main/java/su/terrafirmagreg/core/common/data/blockentity/TickerBlockEntity.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blockentity/TickerBlockEntity.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import su.terrafirmagreg.core.common.data.TFGBlockEntities;
 import su.terrafirmagreg.core.common.data.blocks.ParticleEmitterBlock;
 
-
 // Client based ticker.
 public class TickerBlockEntity extends BlockEntity {
 
@@ -17,7 +16,7 @@ public class TickerBlockEntity extends BlockEntity {
         super(TFGBlockEntities.TICKER_ENTITY.get(), pos, state);
     }
 
-     // Invokes the block's animateTick using RNG.
+    // Invokes the block's animateTick using RNG.
     public static void clientTick(Level level, BlockPos pos, BlockState state, TickerBlockEntity be) {
         if (level.isClientSide && state.getBlock() instanceof ParticleEmitterBlock block) {
             block.animateTick(state, level, pos, level.random);

--- a/src/main/java/su/terrafirmagreg/core/common/data/blockentity/TickerBlockEntity.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blockentity/TickerBlockEntity.java
@@ -8,11 +8,16 @@ import net.minecraft.world.level.block.state.BlockState;
 import su.terrafirmagreg.core.common.data.TFGBlockEntities;
 import su.terrafirmagreg.core.common.data.blocks.ParticleEmitterBlock;
 
+
+// Client based ticker.
 public class TickerBlockEntity extends BlockEntity {
+
+    // Constructs ticker for a particle emitter block.
     public TickerBlockEntity(BlockPos pos, BlockState state) {
         super(TFGBlockEntities.TICKER_ENTITY.get(), pos, state);
     }
 
+     // Invokes the block's animateTick using RNG.
     public static void clientTick(Level level, BlockPos pos, BlockState state, TickerBlockEntity be) {
         if (level.isClientSide && state.getBlock() instanceof ParticleEmitterBlock block) {
             block.animateTick(state, level, pos, level.random);

--- a/src/main/java/su/terrafirmagreg/core/common/data/blockentity/TickerBlockEntity.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blockentity/TickerBlockEntity.java
@@ -1,0 +1,21 @@
+package su.terrafirmagreg.core.common.data.blockentity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import su.terrafirmagreg.core.common.data.TFGBlockEntities;
+import su.terrafirmagreg.core.common.data.blocks.ParticleEmitterBlock;
+
+public class TickerBlockEntity extends BlockEntity {
+    public TickerBlockEntity(BlockPos pos, BlockState state) {
+        super(TFGBlockEntities.TICKER_ENTITY.get(), pos, state);
+    }
+
+    public static void clientTick(Level level, BlockPos pos, BlockState state, TickerBlockEntity be) {
+        if (level.isClientSide && state.getBlock() instanceof ParticleEmitterBlock block) {
+            block.animateTick(state, level, pos, level.random);
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/ActiveParticleBlock.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/ActiveParticleBlock.java
@@ -2,7 +2,6 @@ package su.terrafirmagreg.core.common.data.blocks;
 
 import java.util.function.Supplier;
 
-import dev.latvian.mods.kubejs.typings.Info;
 import org.joml.Vector3f;
 
 import com.gregtechceu.gtceu.api.block.ActiveBlock;
@@ -27,6 +26,8 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+
+import dev.latvian.mods.kubejs.typings.Info;
 
 import su.terrafirmagreg.core.common.data.TFGBlockEntities;
 import su.terrafirmagreg.core.common.data.blockentity.TickerBlockEntity;

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterBlock.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterBlock.java
@@ -6,6 +6,7 @@ import org.joml.Vector3f;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.RandomSource;
@@ -14,6 +15,9 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
@@ -22,34 +26,45 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import dev.latvian.mods.kubejs.typings.Info;
 
-public class ParticleEmitterBlock extends Block {
+import su.terrafirmagreg.core.common.data.TFGBlockEntities;
+import su.terrafirmagreg.core.common.data.blockentity.TickerBlockEntity;
 
+public class ParticleEmitterBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
-    public static final VoxelShape DEFAULT_SHAPE = Block.box(0.0F, 0.0F, 0.0F, 16.0F, 16.0F, 16.0F);
+    public static final VoxelShape DEFAULT_SHAPE = Block.box(0, 0, 0, 16, 16, 16);
+
     private final VoxelShape shape;
     private final Supplier<SimpleParticleType> particleType;
+
+    private final double baseX, baseY, baseZ;
     private final double offsetX, offsetY, offsetZ;
     private final double velocityX, velocityY, velocityZ;
     private final int particleCount;
     private final boolean particleForced;
     private final boolean useDustOptions;
     private final float red, green, blue, scale;
+    private final boolean hasTicker;
 
     public ParticleEmitterBlock(
             Properties properties,
             VoxelShape shape,
             Supplier<Item> itemSupplier,
             Supplier<SimpleParticleType> particleType,
+            double baseX, double baseY, double baseZ,
             double offsetX, double offsetY, double offsetZ,
             double velocityX, double velocityY, double velocityZ,
             int particleCount,
             boolean particleForced,
             boolean useDustOptions,
-            float red, float green, float blue, float scale) {
+            float red, float green, float blue, float scale,
+            boolean hasTicker) {
         super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH));
-        this.shape = shape;
+        this.shape = shape != null ? shape : DEFAULT_SHAPE;
         this.particleType = particleType != null ? particleType : () -> ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+        this.baseX = baseX;
+        this.baseY = baseY;
+        this.baseZ = baseZ;
         this.offsetX = offsetX;
         this.offsetY = offsetY;
         this.offsetZ = offsetZ;
@@ -58,12 +73,12 @@ public class ParticleEmitterBlock extends Block {
         this.velocityZ = velocityZ;
         this.particleCount = Math.max(1, particleCount);
         this.particleForced = particleForced;
-
         this.useDustOptions = useDustOptions;
         this.red = red;
         this.green = green;
         this.blue = blue;
         this.scale = scale;
+        this.hasTicker = hasTicker;
     }
 
     @Override
@@ -91,37 +106,61 @@ public class ParticleEmitterBlock extends Block {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 
-    @Info("create an always visible particle if render type is 'forced' and enable color settings if the particle type is 'minecraft:dust'")
+    @Info("Client visual tick (skipped if ticker entity present).")
     @Override
     public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource random) {
-        for (int i = 0; i < particleCount; i++) {
-            double x = pos.getX() + 0.5 + random.nextDouble() * offsetX * (random.nextBoolean() ? 1 : -1);
-            double y = pos.getY() + random.nextDouble() * offsetY;
-            double z = pos.getZ() + 0.5 + random.nextDouble() * offsetZ * (random.nextBoolean() ? 1 : -1);
+        if (hasTicker && level.getBlockEntity(pos) != null)
+            return;
+        spawnParticlesClient(level, pos, random);
+    }
 
-            if (useDustOptions) {
-                var dust = new net.minecraft.core.particles.DustParticleOptions(
-                        new Vector3f(red, green, blue), scale);
-                if (particleForced) {
-                    level.addAlwaysVisibleParticle(dust, true, x, y, z, velocityX, velocityY, velocityZ);
-                } else {
-                    level.addParticle(dust, x, y, z, velocityX, velocityY, velocityZ);
-                }
-            } else {
-                SimpleParticleType type = particleType.get();
-                if (particleForced) {
-                    level.addAlwaysVisibleParticle(type, true, x, y, z, velocityX, velocityY, velocityZ);
-                } else {
-                    level.addParticle(type, x, y, z, velocityX, velocityY, velocityZ);
-                }
-            }
+    private double randOffset(RandomSource r, double range) {
+        if (range <= 0)
+            return 0;
+        return r.nextDouble() * range * (r.nextBoolean() ? 1 : -1);
+    }
+
+    private void spawnParticlesClient(Level level, BlockPos pos, RandomSource random) {
+        if (!level.isClientSide)
+            return;
+        for (int i = 0; i < particleCount; i++) {
+            double x = pos.getX() + baseX + randOffset(random, offsetX);
+            double y = pos.getY() + baseY + (offsetY > 0 ? random.nextDouble() * offsetY : 0);
+            double z = pos.getZ() + baseZ + randOffset(random, offsetZ);
+            emitClient(level, x, y, z);
+        }
+    }
+
+    private void emitClient(Level level, double x, double y, double z) {
+        if (useDustOptions) {
+            var dust = new DustParticleOptions(new Vector3f(red, green, blue), scale);
+            if (particleForced)
+                level.addAlwaysVisibleParticle(dust, true, x, y, z, velocityX, velocityY, velocityZ);
+            else
+                level.addParticle(dust, x, y, z, velocityX, velocityY, velocityZ);
+        } else {
+            SimpleParticleType type = particleType.get();
+            if (particleForced)
+                level.addAlwaysVisibleParticle(type, true, x, y, z, velocityX, velocityY, velocityZ);
+            else
+                level.addParticle(type, x, y, z, velocityX, velocityY, velocityZ);
         }
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos,
-            boolean movedByPiston) {
-        super.neighborChanged(state, level, pos, neighborBlock, neighborPos, movedByPiston);
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return hasTicker ? new TickerBlockEntity(pos, state) : null;
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+        if (!hasTicker || !level.isClientSide) return null;
+        return type == TFGBlockEntities.TICKER_ENTITY.get()
+                ? (lvl, p, s, be) -> {
+            if (be instanceof TickerBlockEntity t && t.shouldEmit(lvl)) {
+                spawnParticlesClient(lvl, p, lvl.random);
+            }
+        }
+        : null;
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterBlock.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterBlock.java
@@ -172,9 +172,9 @@ public class ParticleEmitterBlock extends Block implements EntityBlock {
             return null;
         return type == TFGBlockEntities.TICKER_ENTITY.get()
                 ? (lvl, p, s, be) -> {
-            if (be instanceof TickerBlockEntity && shouldEmit(lvl.random))
-                spawnParticlesClient(lvl, p, lvl.random);
-        }
+                    if (be instanceof TickerBlockEntity && shouldEmit(lvl.random))
+                        spawnParticlesClient(lvl, p, lvl.random);
+                }
                 : null;
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterDecorationBlock.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterDecorationBlock.java
@@ -2,8 +2,11 @@ package su.terrafirmagreg.core.common.data.blocks;
 
 import java.util.function.Supplier;
 
+import org.joml.Vector3f;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.util.RandomSource;
@@ -13,6 +16,9 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
@@ -21,35 +27,46 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import dev.latvian.mods.kubejs.typings.Info;
 
-public class ParticleEmitterDecorationBlock extends Block {
+import su.terrafirmagreg.core.common.data.TFGBlockEntities;
+import su.terrafirmagreg.core.common.data.blockentity.TickerBlockEntity;
+
+public class ParticleEmitterDecorationBlock extends Block implements EntityBlock {
 
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     public static final VoxelShape DEFAULT_SHAPE = Block.box(2.0F, 0.0F, 2.0F, 14.0F, 16.0F, 14.0F);
 
     private final VoxelShape shape;
     private final Supplier<SimpleParticleType> particleType;
+
+    private final double baseX, baseY, baseZ;
     private final double offsetX, offsetY, offsetZ;
     private final double velocityX, velocityY, velocityZ;
     private final int particleCount;
     private final boolean particleForced;
     private final boolean useDustOptions;
     private final float red, green, blue, scale;
+    private final boolean hasTicker;
 
     public ParticleEmitterDecorationBlock(
             Properties properties,
             VoxelShape shape,
             Supplier<Item> itemSupplier,
             Supplier<SimpleParticleType> particleType,
+            double baseX, double baseY, double baseZ,
             double offsetX, double offsetY, double offsetZ,
             double velocityX, double velocityY, double velocityZ,
             int particleCount,
             boolean particleForced,
             boolean useDustOptions,
-            float red, float green, float blue, float scale) {
+            float red, float green, float blue, float scale,
+            boolean hasTicker) {
         super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH));
-        this.shape = shape;
+        this.shape = shape != null ? shape : DEFAULT_SHAPE;
         this.particleType = particleType != null ? particleType : () -> ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+        this.baseX = baseX;
+        this.baseY = baseY;
+        this.baseZ = baseZ;
         this.offsetX = offsetX;
         this.offsetY = offsetY;
         this.offsetZ = offsetZ;
@@ -58,22 +75,22 @@ public class ParticleEmitterDecorationBlock extends Block {
         this.velocityZ = velocityZ;
         this.particleCount = Math.max(1, particleCount);
         this.particleForced = particleForced;
-
         this.useDustOptions = useDustOptions;
         this.red = red;
         this.green = green;
         this.blue = blue;
         this.scale = scale;
-    }
-
-    @Override
-    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        return shape != null ? shape : super.getShape(state, level, pos, context);
+        this.hasTicker = hasTicker;
     }
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(FACING);
+    }
+
+    @Override
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return shape;
     }
 
     @Override
@@ -97,31 +114,62 @@ public class ParticleEmitterDecorationBlock extends Block {
         return level.getBlockState(below).isFaceSturdy(level, below, Direction.UP);
     }
 
-    @Info("create an always visible particle if render type is 'forced' and enable color settings if the particle type is 'minecraft:dust'")
+    @Info("Client visual tick (skipped if ticker entity present).")
     @Override
     public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource random) {
-        for (int i = 0; i < particleCount; i++) {
-            double x = pos.getX() + 0.5 + random.nextDouble() * offsetX * (random.nextBoolean() ? 1 : -1);
-            double y = pos.getY() + random.nextDouble() * offsetY;
-            double z = pos.getZ() + 0.5 + random.nextDouble() * offsetZ * (random.nextBoolean() ? 1 : -1);
+        if (hasTicker && level.getBlockEntity(pos) != null)
+            return;
+        spawnClient(level, pos, random);
+    }
 
-            if (useDustOptions) {
-                var dust = new net.minecraft.core.particles.DustParticleOptions(
-                        new org.joml.Vector3f(red, green, blue), scale);
-                if (particleForced) {
-                    level.addAlwaysVisibleParticle(dust, true, x, y, z, velocityX, velocityY, velocityZ);
-                } else {
-                    level.addParticle(dust, x, y, z, velocityX, velocityY, velocityZ);
-                }
-            } else {
-                SimpleParticleType type = particleType.get();
-                if (particleForced) {
-                    level.addAlwaysVisibleParticle(type, true, x, y, z, velocityX, velocityY, velocityZ);
-                } else {
-                    level.addParticle(type, x, y, z, velocityX, velocityY, velocityZ);
-                }
-            }
+    private double randOffset(RandomSource r, double range) {
+        if (range <= 0)
+            return 0;
+        return r.nextDouble() * range * (r.nextBoolean() ? 1 : -1);
+    }
+
+    private void spawnClient(Level level, BlockPos pos, RandomSource random) {
+        if (!level.isClientSide)
+            return;
+        for (int i = 0; i < particleCount; i++) {
+            double x = pos.getX() + baseX + randOffset(random, offsetX);
+            double y = pos.getY() + baseY + (offsetY > 0 ? random.nextDouble() * offsetY : 0);
+            double z = pos.getZ() + baseZ + randOffset(random, offsetZ);
+            emitClient(level, x, y, z);
         }
+    }
+
+    private void emitClient(Level level, double x, double y, double z) {
+        if (useDustOptions) {
+            var dust = new DustParticleOptions(new Vector3f(red, green, blue), scale);
+            if (particleForced)
+                level.addAlwaysVisibleParticle(dust, true, x, y, z, velocityX, velocityY, velocityZ);
+            else
+                level.addParticle(dust, x, y, z, velocityX, velocityY, velocityZ);
+        } else {
+            SimpleParticleType type = particleType.get();
+            if (particleForced)
+                level.addAlwaysVisibleParticle(type, true, x, y, z, velocityX, velocityY, velocityZ);
+            else
+                level.addParticle(type, x, y, z, velocityX, velocityY, velocityZ);
+        }
+    }
+
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return hasTicker ? new TickerBlockEntity(pos, state) : null;
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+        if (!hasTicker || !level.isClientSide)
+            return null;
+        return type == TFGBlockEntities.TICKER_ENTITY.get()
+                ? (lvl, p, s, be) -> {
+                    if (be instanceof TickerBlockEntity)
+                        spawnClient(lvl, p, lvl.random);
+                }
+                : null;
     }
 
     @Override

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterDecorationBlock.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/ParticleEmitterDecorationBlock.java
@@ -179,16 +179,16 @@ public class ParticleEmitterDecorationBlock extends Block implements EntityBlock
             return null;
         return type == TFGBlockEntities.TICKER_ENTITY.get()
                 ? (lvl, p, s, be) -> {
-            if (be instanceof TickerBlockEntity && shouldEmit(lvl.random))
-                spawnClient(lvl, p, lvl.random);
-        }
+                    if (be instanceof TickerBlockEntity && shouldEmit(lvl.random))
+                        spawnClient(lvl, p, lvl.random);
+                }
                 : null;
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos,
-                                boolean movedByPiston) {
+            boolean movedByPiston) {
         super.neighborChanged(state, level, pos, neighborBlock, neighborPos, movedByPiston);
         if (!canSurvive(state, level, pos)) {
             Block.updateOrDestroy(state, Blocks.AIR.defaultBlockState(), level, pos, Block.UPDATE_ALL);

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/GTActiveParticleBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/GTActiveParticleBuilder.java
@@ -31,8 +31,7 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     public transient Supplier<Item> itemBuilder;
 
     // Inactive defaults
-    private transient Supplier<SimpleParticleType> inactiveParticle =
-            () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.ASH;
+    private transient Supplier<SimpleParticleType> inactiveParticle = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.ASH;
     private transient boolean hasInactive = false;
     private transient double inactiveBaseX = 0.5, inactiveBaseY = 0.5, inactiveBaseZ = 0.5;
     private transient double inactiveOffsetX, inactiveOffsetY, inactiveOffsetZ;
@@ -43,8 +42,7 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     private transient float inactiveDustRed, inactiveDustGreen, inactiveDustBlue, inactiveDustScale;
 
     // Active defaults
-    private transient Supplier<SimpleParticleType> activeParticle =
-            () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+    private transient Supplier<SimpleParticleType> activeParticle = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
     private transient boolean hasActive = false;
     private transient double activeBaseX = 0.5, activeBaseY = 0.5, activeBaseZ = 0.5;
     private transient double activeOffsetX, activeOffsetY, activeOffsetZ;
@@ -86,19 +84,25 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
 
     @Info("Inactive base position.")
     public GTActiveParticleBuilder inactiveBase(double x, double y, double z) {
-        this.inactiveBaseX = x; this.inactiveBaseY = y; this.inactiveBaseZ = z;
+        this.inactiveBaseX = x;
+        this.inactiveBaseY = y;
+        this.inactiveBaseZ = z;
         return this;
     }
 
     @Info("Inactive spread offsets.")
     public GTActiveParticleBuilder inactiveOffset(double x, double y, double z) {
-        this.inactiveOffsetX = x; this.inactiveOffsetY = y; this.inactiveOffsetZ = z;
+        this.inactiveOffsetX = x;
+        this.inactiveOffsetY = y;
+        this.inactiveOffsetZ = z;
         return this;
     }
 
     @Info("Inactive velocity.")
     public GTActiveParticleBuilder inactiveVelocity(double x, double y, double z) {
-        this.inactiveVelX = x; this.inactiveVelY = y; this.inactiveVelZ = z;
+        this.inactiveVelX = x;
+        this.inactiveVelY = y;
+        this.inactiveVelZ = z;
         return this;
     }
 
@@ -117,7 +121,10 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     @Info("Inactive dust color + scale.")
     public GTActiveParticleBuilder inactiveDust(float r, float g, float b, float scale) {
         this.inactiveUseDust = true;
-        this.inactiveDustRed = r; this.inactiveDustGreen = g; this.inactiveDustBlue = b; this.inactiveDustScale = scale;
+        this.inactiveDustRed = r;
+        this.inactiveDustGreen = g;
+        this.inactiveDustBlue = b;
+        this.inactiveDustScale = scale;
         return this;
     }
 
@@ -133,19 +140,25 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
 
     @Info("Active base position.")
     public GTActiveParticleBuilder activeBase(double x, double y, double z) {
-        this.activeBaseX = x; this.activeBaseY = y; this.activeBaseZ = z;
+        this.activeBaseX = x;
+        this.activeBaseY = y;
+        this.activeBaseZ = z;
         return this;
     }
 
     @Info("Active spread offsets.")
     public GTActiveParticleBuilder activeOffset(double x, double y, double z) {
-        this.activeOffsetX = x; this.activeOffsetY = y; this.activeOffsetZ = z;
+        this.activeOffsetX = x;
+        this.activeOffsetY = y;
+        this.activeOffsetZ = z;
         return this;
     }
 
     @Info("Active velocity.")
     public GTActiveParticleBuilder activeVelocity(double x, double y, double z) {
-        this.activeVelX = x; this.activeVelY = y; this.activeVelZ = z;
+        this.activeVelX = x;
+        this.activeVelY = y;
+        this.activeVelZ = z;
         return this;
     }
 
@@ -164,7 +177,10 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     @Info("Active dust color + scale.")
     public GTActiveParticleBuilder activeDust(float r, float g, float b, float scale) {
         this.activeUseDust = true;
-        this.activeDustRed = r; this.activeDustGreen = g; this.activeDustBlue = b; this.activeDustScale = scale;
+        this.activeDustRed = r;
+        this.activeDustGreen = g;
+        this.activeDustBlue = b;
+        this.activeDustScale = scale;
         return this;
     }
 

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/GTActiveParticleBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/GTActiveParticleBuilder.java
@@ -1,5 +1,7 @@
 package su.terrafirmagreg.core.compat.kjs;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import com.gregtechceu.gtceu.api.block.property.GTBlockStateProperties;
@@ -18,28 +20,18 @@ import dev.latvian.mods.rhino.util.HideFromJS;
 import su.terrafirmagreg.core.common.data.blocks.ActiveParticleBlock;
 import su.terrafirmagreg.core.common.data.blocks.ActiveParticleBlock.ParticleConfig;
 
-/**
- * KubeJS builder for ActiveParticleBlock.
- * Allows independent particle configs for active and inactive states.
- */
 public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
 
-    /**
-     * The Cached shape.
-     */
+    public static final List<net.minecraft.world.level.block.Block> REGISTERED_BLOCKS = new ArrayList<>();
+
     public transient VoxelShape cachedShape;
-    /**
-     * The Preexisting item.
-     */
     public transient Supplier<Item> preexistingItem;
-    /**
-     * The Item builder.
-     */
     public transient Supplier<Item> itemBuilder;
 
-    // Inactive Config
+    // Inactive
     private transient Supplier<SimpleParticleType> inactiveParticle = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.ASH;
     private transient boolean hasInactive = false;
+    private transient double inactiveBaseX = 0.5, inactiveBaseY = 0.5, inactiveBaseZ = 0.5;
     private transient double inactiveOffsetX, inactiveOffsetY, inactiveOffsetZ;
     private transient double inactiveVelX, inactiveVelY, inactiveVelZ;
     private transient int inactiveCount = 1;
@@ -47,9 +39,10 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     private transient boolean inactiveUseDust = false;
     private transient float inactiveDustRed, inactiveDustGreen, inactiveDustBlue, inactiveDustScale;
 
-    // Active Config
+    // Active
     private transient Supplier<SimpleParticleType> activeParticle = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
     private transient boolean hasActive = false;
+    private transient double activeBaseX = 0.5, activeBaseY = 0.5, activeBaseZ = 0.5;
     private transient double activeOffsetX, activeOffsetY, activeOffsetZ;
     private transient double activeVelX, activeVelY, activeVelZ;
     private transient int activeCount = 1;
@@ -57,36 +50,32 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     private transient boolean activeUseDust = false;
     private transient float activeDustRed, activeDustGreen, activeDustBlue, activeDustScale;
 
-    /**
-     * Instantiates a new Gt active particle builder.
-     *
-     * @param id the id
-     */
+    private transient boolean hasTicker = false;
+
     public GTActiveParticleBuilder(ResourceLocation id) {
         super(id);
         property(GTBlockStateProperties.ACTIVE);
     }
 
-    /**
-     * Inactive particle gt active particle builder.
-     *
-     * @param id the id
-     * @return the gt active particle builder
-     */
+    public GTActiveParticleBuilder hasTicker(boolean enabled) {
+        this.hasTicker = enabled;
+        return this;
+    }
+
+    // Inactive
     public GTActiveParticleBuilder inactiveParticle(String id) {
         this.inactiveParticle = resolveParticle(id, true);
         this.hasInactive = true;
         return this;
     }
 
-    /**
-     * Inactive offset gt active particle builder.
-     *
-     * @param x the x
-     * @param y the y
-     * @param z the z
-     * @return the gt active particle builder
-     */
+    public GTActiveParticleBuilder inactiveBase(double x, double y, double z) {
+        this.inactiveBaseX = x;
+        this.inactiveBaseY = y;
+        this.inactiveBaseZ = z;
+        return this;
+    }
+
     public GTActiveParticleBuilder inactiveOffset(double x, double y, double z) {
         this.inactiveOffsetX = x;
         this.inactiveOffsetY = y;
@@ -94,14 +83,6 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return this;
     }
 
-    /**
-     * Inactive velocity gt active particle builder.
-     *
-     * @param x the x
-     * @param y the y
-     * @param z the z
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder inactiveVelocity(double x, double y, double z) {
         this.inactiveVelX = x;
         this.inactiveVelY = y;
@@ -109,37 +90,16 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return this;
     }
 
-    /**
-     * Inactive count gt active particle builder.
-     *
-     * @param count the count
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder inactiveCount(int count) {
         this.inactiveCount = count;
         return this;
     }
 
-    /**
-     * Inactive forced gt active particle builder.
-     *
-     * @param forced the forced
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder inactiveForced(boolean forced) {
         this.inactiveForced = forced;
         return this;
     }
 
-    /**
-     * Inactive dust gt active particle builder.
-     *
-     * @param r     the r
-     * @param g     the g
-     * @param b     the b
-     * @param scale the scale
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder inactiveDust(float r, float g, float b, float scale) {
         this.inactiveUseDust = true;
         this.inactiveDustRed = r;
@@ -149,26 +109,20 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return this;
     }
 
-    /**
-     * Active particle gt active particle builder.
-     *
-     * @param id the id
-     * @return the gt active particle builder
-     */
+    // Active
     public GTActiveParticleBuilder activeParticle(String id) {
         this.activeParticle = resolveParticle(id, false);
         this.hasActive = true;
         return this;
     }
 
-    /**
-     * Active offset gt active particle builder.
-     *
-     * @param x the x
-     * @param y the y
-     * @param z the z
-     * @return the gt active particle builder
-     */
+    public GTActiveParticleBuilder activeBase(double x, double y, double z) {
+        this.activeBaseX = x;
+        this.activeBaseY = y;
+        this.activeBaseZ = z;
+        return this;
+    }
+
     public GTActiveParticleBuilder activeOffset(double x, double y, double z) {
         this.activeOffsetX = x;
         this.activeOffsetY = y;
@@ -176,14 +130,6 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return this;
     }
 
-    /**
-     * Active velocity gt active particle builder.
-     *
-     * @param x the x
-     * @param y the y
-     * @param z the z
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder activeVelocity(double x, double y, double z) {
         this.activeVelX = x;
         this.activeVelY = y;
@@ -191,37 +137,16 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return this;
     }
 
-    /**
-     * Active count gt active particle builder.
-     *
-     * @param count the count
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder activeCount(int count) {
         this.activeCount = count;
         return this;
     }
 
-    /**
-     * Active forced gt active particle builder.
-     *
-     * @param forced the forced
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder activeForced(boolean forced) {
         this.activeForced = forced;
         return this;
     }
 
-    /**
-     * Active dust gt active particle builder.
-     *
-     * @param r     the r
-     * @param g     the g
-     * @param b     the b
-     * @param scale the scale
-     * @return the gt active particle builder
-     */
     public GTActiveParticleBuilder activeDust(float r, float g, float b, float scale) {
         this.activeUseDust = true;
         this.activeDustRed = r;
@@ -231,27 +156,15 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return this;
     }
 
-    /**
-     * Gets shape.
-     *
-     * @return the shape
-     */
     @HideFromJS
     public VoxelShape getShape() {
-        if (customShape.isEmpty()) {
+        if (customShape.isEmpty())
             return ActiveParticleBlock.DEFAULT_SHAPE;
-        }
-        if (cachedShape == null) {
+        if (cachedShape == null)
             cachedShape = BlockBuilder.createShape(customShape);
-        }
         return cachedShape;
     }
 
-    /**
-     * Item supplier supplier.
-     *
-     * @return the supplier
-     */
     @HideFromJS
     public Supplier<Item> itemSupplier() {
         if (preexistingItem != null)
@@ -264,33 +177,32 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     @Override
     public ActiveParticleBlock createObject() {
         ParticleConfig inactiveCfg = hasInactive ? new ParticleConfig(
-                inactiveParticle, inactiveOffsetX, inactiveOffsetY, inactiveOffsetZ,
+                inactiveParticle,
+                inactiveBaseX, inactiveBaseY, inactiveBaseZ,
+                inactiveOffsetX, inactiveOffsetY, inactiveOffsetZ,
                 inactiveVelX, inactiveVelY, inactiveVelZ,
                 inactiveCount, inactiveForced,
                 inactiveUseDust, inactiveDustRed, inactiveDustGreen, inactiveDustBlue, inactiveDustScale) : null;
 
         ParticleConfig activeCfg = hasActive ? new ParticleConfig(
-                activeParticle, activeOffsetX, activeOffsetY, activeOffsetZ,
+                activeParticle,
+                activeBaseX, activeBaseY, activeBaseZ,
+                activeOffsetX, activeOffsetY, activeOffsetZ,
                 activeVelX, activeVelY, activeVelZ,
                 activeCount, activeForced,
                 activeUseDust, activeDustRed, activeDustGreen, activeDustBlue, activeDustScale) : null;
 
-        return new ActiveParticleBlock(
+        var block = new ActiveParticleBlock(
                 createProperties(),
                 getShape(),
                 itemSupplier(),
                 inactiveCfg,
-                activeCfg);
-    }
-
-    /**
-     * Item supplier public supplier.
-     *
-     * @return the supplier
-     */
-    @HideFromJS
-    public Supplier<Item> itemSupplierPublic() {
-        return itemSupplier();
+                activeCfg,
+                hasTicker);
+        if (hasTicker) {
+            REGISTERED_BLOCKS.add(block);
+        }
+        return block;
     }
 
     private Supplier<SimpleParticleType> resolveParticle(String id, boolean isInactive) {

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/GTActiveParticleBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/GTActiveParticleBuilder.java
@@ -15,11 +15,13 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import dev.latvian.mods.kubejs.block.BlockBuilder;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
+import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.rhino.util.HideFromJS;
 
 import su.terrafirmagreg.core.common.data.blocks.ActiveParticleBlock;
 import su.terrafirmagreg.core.common.data.blocks.ActiveParticleBlock.ParticleConfig;
 
+// KubeJS Builder for an GT active/inactive dual particle block.
 public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
 
     public static final List<net.minecraft.world.level.block.Block> REGISTERED_BLOCKS = new ArrayList<>();
@@ -28,8 +30,9 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     public transient Supplier<Item> preexistingItem;
     public transient Supplier<Item> itemBuilder;
 
-    // Inactive
-    private transient Supplier<SimpleParticleType> inactiveParticle = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.ASH;
+    // Inactive defaults
+    private transient Supplier<SimpleParticleType> inactiveParticle =
+            () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.ASH;
     private transient boolean hasInactive = false;
     private transient double inactiveBaseX = 0.5, inactiveBaseY = 0.5, inactiveBaseZ = 0.5;
     private transient double inactiveOffsetX, inactiveOffsetY, inactiveOffsetZ;
@@ -39,8 +42,9 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     private transient boolean inactiveUseDust = false;
     private transient float inactiveDustRed, inactiveDustGreen, inactiveDustBlue, inactiveDustScale;
 
-    // Active
-    private transient Supplier<SimpleParticleType> activeParticle = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+    // Active defaults
+    private transient Supplier<SimpleParticleType> activeParticle =
+            () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
     private transient boolean hasActive = false;
     private transient double activeBaseX = 0.5, activeBaseY = 0.5, activeBaseZ = 0.5;
     private transient double activeOffsetX, activeOffsetY, activeOffsetZ;
@@ -51,108 +55,116 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
     private transient float activeDustRed, activeDustGreen, activeDustBlue, activeDustScale;
 
     private transient boolean hasTicker = false;
+    private transient int emitDelay = 0;
 
     public GTActiveParticleBuilder(ResourceLocation id) {
         super(id);
         property(GTBlockStateProperties.ACTIVE);
     }
 
+    @Info("Enable/disable block entity ticker (default false).")
     public GTActiveParticleBuilder hasTicker(boolean enabled) {
         this.hasTicker = enabled;
         return this;
     }
 
-    // Inactive
+    @Info("Random emission delay scale")
+    public GTActiveParticleBuilder emitDelay(int delay) {
+        this.emitDelay = Math.max(0, delay);
+        return this;
+    }
+
+    /**
+     * Inactive particle configuration.
+     */
+    @Info("Inactive particle id.")
     public GTActiveParticleBuilder inactiveParticle(String id) {
         this.inactiveParticle = resolveParticle(id, true);
         this.hasInactive = true;
         return this;
     }
 
+    @Info("Inactive base position.")
     public GTActiveParticleBuilder inactiveBase(double x, double y, double z) {
-        this.inactiveBaseX = x;
-        this.inactiveBaseY = y;
-        this.inactiveBaseZ = z;
+        this.inactiveBaseX = x; this.inactiveBaseY = y; this.inactiveBaseZ = z;
         return this;
     }
 
+    @Info("Inactive spread offsets.")
     public GTActiveParticleBuilder inactiveOffset(double x, double y, double z) {
-        this.inactiveOffsetX = x;
-        this.inactiveOffsetY = y;
-        this.inactiveOffsetZ = z;
+        this.inactiveOffsetX = x; this.inactiveOffsetY = y; this.inactiveOffsetZ = z;
         return this;
     }
 
+    @Info("Inactive velocity.")
     public GTActiveParticleBuilder inactiveVelocity(double x, double y, double z) {
-        this.inactiveVelX = x;
-        this.inactiveVelY = y;
-        this.inactiveVelZ = z;
+        this.inactiveVelX = x; this.inactiveVelY = y; this.inactiveVelZ = z;
         return this;
     }
 
+    @Info("Inactive particle count.")
     public GTActiveParticleBuilder inactiveCount(int count) {
         this.inactiveCount = count;
         return this;
     }
 
+    @Info("Inactive always visible.")
     public GTActiveParticleBuilder inactiveForced(boolean forced) {
         this.inactiveForced = forced;
         return this;
     }
 
+    @Info("Inactive dust color + scale.")
     public GTActiveParticleBuilder inactiveDust(float r, float g, float b, float scale) {
         this.inactiveUseDust = true;
-        this.inactiveDustRed = r;
-        this.inactiveDustGreen = g;
-        this.inactiveDustBlue = b;
-        this.inactiveDustScale = scale;
+        this.inactiveDustRed = r; this.inactiveDustGreen = g; this.inactiveDustBlue = b; this.inactiveDustScale = scale;
         return this;
     }
 
-    // Active
+    /**
+     * Active particle configuration.
+     */
+    @Info("Active particle id.")
     public GTActiveParticleBuilder activeParticle(String id) {
         this.activeParticle = resolveParticle(id, false);
         this.hasActive = true;
         return this;
     }
 
+    @Info("Active base position.")
     public GTActiveParticleBuilder activeBase(double x, double y, double z) {
-        this.activeBaseX = x;
-        this.activeBaseY = y;
-        this.activeBaseZ = z;
+        this.activeBaseX = x; this.activeBaseY = y; this.activeBaseZ = z;
         return this;
     }
 
+    @Info("Active spread offsets.")
     public GTActiveParticleBuilder activeOffset(double x, double y, double z) {
-        this.activeOffsetX = x;
-        this.activeOffsetY = y;
-        this.activeOffsetZ = z;
+        this.activeOffsetX = x; this.activeOffsetY = y; this.activeOffsetZ = z;
         return this;
     }
 
+    @Info("Active velocity.")
     public GTActiveParticleBuilder activeVelocity(double x, double y, double z) {
-        this.activeVelX = x;
-        this.activeVelY = y;
-        this.activeVelZ = z;
+        this.activeVelX = x; this.activeVelY = y; this.activeVelZ = z;
         return this;
     }
 
+    @Info("Active particle count.")
     public GTActiveParticleBuilder activeCount(int count) {
         this.activeCount = count;
         return this;
     }
 
+    @Info("Active always visible.")
     public GTActiveParticleBuilder activeForced(boolean forced) {
         this.activeForced = forced;
         return this;
     }
 
+    @Info("Active dust color + scale.")
     public GTActiveParticleBuilder activeDust(float r, float g, float b, float scale) {
         this.activeUseDust = true;
-        this.activeDustRed = r;
-        this.activeDustGreen = g;
-        this.activeDustBlue = b;
-        this.activeDustScale = scale;
+        this.activeDustRed = r; this.activeDustGreen = g; this.activeDustBlue = b; this.activeDustScale = scale;
         return this;
     }
 
@@ -174,6 +186,7 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
         return null;
     }
 
+    // Creates dual-state particle block with optional ticker registration.
     @Override
     public ActiveParticleBlock createObject() {
         ParticleConfig inactiveCfg = hasInactive ? new ParticleConfig(
@@ -198,7 +211,8 @@ public class GTActiveParticleBuilder extends ExtendedPropertiesBlockBuilder {
                 itemSupplier(),
                 inactiveCfg,
                 activeCfg,
-                hasTicker);
+                hasTicker,
+                emitDelay);
         if (hasTicker) {
             REGISTERED_BLOCKS.add(block);
         }

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterBlockBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterBlockBuilder.java
@@ -1,15 +1,17 @@
 package su.terrafirmagreg.core.compat.kjs;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import com.notenoughmail.kubejs_tfc.block.internal.ExtendedPropertiesBlockBuilder;
-import com.notenoughmail.kubejs_tfc.event.RegisterInteractionsEventJS;
 
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.common.util.Lazy;
@@ -23,11 +25,15 @@ import su.terrafirmagreg.core.common.data.blocks.ParticleEmitterBlock;
 
 public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder {
 
+    public static final List<net.minecraft.world.level.block.Block> REGISTERED_BLOCKS = new ArrayList<>();
+
     public transient VoxelShape cachedShape;
     public transient Supplier<Item> preexistingItem;
-    public transient int rotate;
+    public transient Supplier<Item> itemBuilder;
 
     public transient Supplier<SimpleParticleType> particleType = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+
+    public transient double baseX = 0.5, baseY = 0.5, baseZ = 0.5;
     public transient double offsetX = 0.25, offsetY = 1.0, offsetZ = 0.25;
     public transient double velocityX = 0.0, velocityY = 0.07, velocityZ = 0.0;
     public transient int particleCount = 1;
@@ -35,43 +41,46 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
     public transient boolean useDustOptions = false;
     public transient float dustRed = 1.0f, dustGreen = 0.0f, dustBlue = 0.0f, dustScale = 1.0f;
 
-    public ParticleEmitterBlockBuilder(ResourceLocation i) {
-        super(i);
-        hardness = 1.5f;
-        resistance = 6;
-        rotate = 0;
-        soundType = SoundType.STONE;
+    private transient boolean hasTicker = false;
 
-        mapColor(MapColor.NONE);
+    public ParticleEmitterBlockBuilder(ResourceLocation id) {
+        super(id);
+        soundType = SoundType.STONE;
+        hardness = 1.5f;
+        resistance = 6.0f;
+        mapColor(MapColor.STONE);
     }
 
-    @Info("Sets the 'block item' of this block to an existing item")
-    public ParticleEmitterBlockBuilder withPreexistingItem(ResourceLocation item) {
-        itemBuilder = null;
-        preexistingItem = Lazy.of(() -> RegistryInfo.ITEM.getValue(item));
-        RegisterInteractionsEventJS.addBlockItemPlacement(preexistingItem, this);
+    @Info("Enable/disable block entity ticker (default true)")
+    public ParticleEmitterBlockBuilder hasTicker(boolean enabled) {
+        this.hasTicker = enabled;
         return this;
     }
 
-    @Info("Sets the particle type emitted by the block (example: 'minecraft:bubble')")
+    @Info("Sets the initial base position inside the block (default 0.5, 0.5, 0.5)")
+    public ParticleEmitterBlockBuilder particleBase(double x, double y, double z) {
+        baseX = x;
+        baseY = y;
+        baseZ = z;
+        return this;
+    }
+
+    @Info("Sets the particle type (example: 'minecraft:bubble')")
     public ParticleEmitterBlockBuilder particle(String id) {
         ResourceLocation rl = ResourceLocation.tryParse(id);
         particleType = Lazy.of(() -> {
             ParticleType<?> pt = RegistryInfo.PARTICLE_TYPE.getValue(rl);
             if (pt instanceof SimpleParticleType simple) {
+                if (id.equals("minecraft:dust"))
+                    useDustOptions = true;
                 return simple;
             }
             throw new IllegalArgumentException("Particle type '" + id + "' is not a SimpleParticleType");
         });
-
-        if (id.equals("minecraft:dust")) {
-            useDustOptions = true;
-        }
-
         return this;
     }
 
-    @Info("Sets the offset range for particles (default: 0.25, 1.0, 0.25)")
+    @Info("Sets random spread ranges (default 0.25,1.0,0.25)")
     public ParticleEmitterBlockBuilder particleOffset(double x, double y, double z) {
         offsetX = x;
         offsetY = y;
@@ -79,7 +88,7 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
         return this;
     }
 
-    @Info("Sets the particle velocity (default: 0.0, 0.07, 0.0)")
+    @Info("Sets particle velocity (default 0,0.07,0)")
     public ParticleEmitterBlockBuilder particleVelocity(double x, double y, double z) {
         velocityX = x;
         velocityY = y;
@@ -87,35 +96,40 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
         return this;
     }
 
-    @Info("Sets the number of particles emitted per tick (default: 1)")
+    @Info("Sets number of particles per emission (default 1)")
     public ParticleEmitterBlockBuilder particleCount(int count) {
         particleCount = count;
         return this;
     }
 
-    @Info("If true, particles are always visible in 512 blocks and on minimal visual setting. Normal is 32 blocks. (default: false)")
+    @Info("Particles always visible (default false)")
     public ParticleEmitterBlockBuilder particleForced(boolean forced) {
         particleForced = forced;
         return this;
     }
 
-    @Info("Set RGB color and scale for 'dust' particle type (float from 0.0 to 1.0)")
+    @Info("Dust particle RGB + scale")
     public ParticleEmitterBlockBuilder dustColor(float r, float g, float b, float scale) {
-        this.dustRed = r;
-        this.dustGreen = g;
-        this.dustBlue = b;
-        this.dustScale = scale;
+        dustRed = r;
+        dustGreen = g;
+        dustBlue = b;
+        dustScale = scale;
+        return this;
+    }
+
+    @Info("Use an existing item as the block item")
+    public ParticleEmitterBlockBuilder withPreexistingItem(ResourceLocation item) {
+        itemBuilder = null;
+        preexistingItem = Lazy.of(() -> RegistryInfo.ITEM.getValue(item));
         return this;
     }
 
     @HideFromJS
     public VoxelShape getShape() {
-        if (customShape.isEmpty()) {
+        if (customShape.isEmpty())
             return ParticleEmitterBlock.DEFAULT_SHAPE;
-        }
-        if (cachedShape == null) {
+        if (cachedShape == null)
             cachedShape = BlockBuilder.createShape(customShape);
-        }
         return cachedShape;
     }
 
@@ -130,16 +144,23 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
 
     @Override
     public ParticleEmitterBlock createObject() {
-        return new ParticleEmitterBlock(
-                createProperties(),
+        BlockBehaviour.Properties props = createProperties();
+        ParticleEmitterBlock block = new ParticleEmitterBlock(
+                props,
                 getShape(),
                 itemSupplier(),
                 particleType,
+                baseX, baseY, baseZ,
                 offsetX, offsetY, offsetZ,
                 velocityX, velocityY, velocityZ,
                 particleCount,
                 particleForced,
                 useDustOptions,
-                dustRed, dustGreen, dustBlue, dustScale);
+                dustRed, dustGreen, dustBlue, dustScale,
+                hasTicker);
+        if (hasTicker) {
+            REGISTERED_BLOCKS.add(block);
+        }
+        return block;
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterBlockBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterBlockBuilder.java
@@ -63,9 +63,11 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
         return this;
     }
 
-    @Info("Starting emission position (default 0.5, 0.5, 0.5).")
+    @Info("Starting emission position (default: center -> 0.5, 0.5, 0.5).")
     public ParticleEmitterBlockBuilder particleBase(double x, double y, double z) {
-        baseX = x; baseY = y; baseZ = z;
+        baseX = x;
+        baseY = y;
+        baseZ = z;
         return this;
     }
 
@@ -86,13 +88,17 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
 
     @Info("Random spread ranges (default 0.25, 1.0, 0.25).")
     public ParticleEmitterBlockBuilder particleOffset(double x, double y, double z) {
-        offsetX = x; offsetY = y; offsetZ = z;
+        offsetX = x;
+        offsetY = y;
+        offsetZ = z;
         return this;
     }
 
     @Info("Particle velocity (default 0, 0, 0).")
     public ParticleEmitterBlockBuilder particleVelocity(double x, double y, double z) {
-        velocityX = x; velocityY = y; velocityZ = z;
+        velocityX = x;
+        velocityY = y;
+        velocityZ = z;
         return this;
     }
 
@@ -110,7 +116,10 @@ public class ParticleEmitterBlockBuilder extends ExtendedPropertiesBlockBuilder 
 
     @Info("Dust color r, g, b + scale (only if dust particle chosen).")
     public ParticleEmitterBlockBuilder dustColor(float r, float g, float b, float scale) {
-        dustRed = r; dustGreen = g; dustBlue = b; dustScale = scale;
+        dustRed = r;
+        dustGreen = g;
+        dustBlue = b;
+        dustScale = scale;
         return this;
     }
 

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterDecorationBlockBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterDecorationBlockBuilder.java
@@ -34,8 +34,7 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
     public transient int rotate;
 
     // Particle configuration defaults.
-    public transient Supplier<SimpleParticleType> particleType =
-            () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+    public transient Supplier<SimpleParticleType> particleType = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
     public transient double baseX = 0.5, baseY = 0.5, baseZ = 0.5;
     public transient double offsetX = 0.25, offsetY = 1.0, offsetZ = 0.25;
     public transient double velocityX = 0.0, velocityY = 0.0, velocityZ = 0.0;
@@ -71,9 +70,11 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
         return this;
     }
 
-    @Info("Starting emission position (default 0.5, 0.5, 0.5).")
+    @Info("Starting emission position (default: center -> 0.5, 0.5, 0.5).")
     public ParticleEmitterDecorationBlockBuilder particleBase(double x, double y, double z) {
-        baseX = x; baseY = y; baseZ = z;
+        baseX = x;
+        baseY = y;
+        baseZ = z;
         return this;
     }
 
@@ -108,13 +109,17 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
 
     @Info("Random spread ranges (default 0.25, 1.0, 0.25).")
     public ParticleEmitterDecorationBlockBuilder particleOffset(double x, double y, double z) {
-        offsetX = x; offsetY = y; offsetZ = z;
+        offsetX = x;
+        offsetY = y;
+        offsetZ = z;
         return this;
     }
 
     @Info("Particle velocity (default 0, 0, 0).")
     public ParticleEmitterDecorationBlockBuilder particleVelocity(double x, double y, double z) {
-        velocityX = x; velocityY = y; velocityZ = z;
+        velocityX = x;
+        velocityY = y;
+        velocityZ = z;
         return this;
     }
 
@@ -132,7 +137,10 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
 
     @Info("Dust color r, g, b + scale (only if dust particle chosen).")
     public ParticleEmitterDecorationBlockBuilder dustColor(float r, float g, float b, float scale) {
-        dustRed = r; dustGreen = g; dustBlue = b; dustScale = scale;
+        dustRed = r;
+        dustGreen = g;
+        dustBlue = b;
+        dustScale = scale;
         return this;
     }
 

--- a/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterDecorationBlockBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/kjs/ParticleEmitterDecorationBlockBuilder.java
@@ -1,5 +1,7 @@
 package su.terrafirmagreg.core.compat.kjs;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import com.notenoughmail.kubejs_tfc.block.internal.ExtendedPropertiesBlockBuilder;
@@ -24,11 +26,15 @@ import su.terrafirmagreg.core.common.data.blocks.ParticleEmitterDecorationBlock;
 
 public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlockBuilder {
 
+    public static final List<net.minecraft.world.level.block.Block> REGISTERED_BLOCKS = new ArrayList<>();
+
     public transient VoxelShape cachedShape;
     public transient Supplier<Item> preexistingItem;
     public transient int rotate;
 
     public transient Supplier<SimpleParticleType> particleType = () -> (SimpleParticleType) net.minecraft.core.particles.ParticleTypes.CAMPFIRE_SIGNAL_SMOKE;
+
+    public transient double baseX = 0.5, baseY = 0.5, baseZ = 0.5;
     public transient double offsetX = 0.25, offsetY = 1.0, offsetZ = 0.25;
     public transient double velocityX = 0.0, velocityY = 0.07, velocityZ = 0.0;
     public transient int particleCount = 1;
@@ -36,9 +42,10 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
     public transient boolean useDustOptions = false;
     public transient float dustRed = 1.0f, dustGreen = 0.0f, dustBlue = 0.0f, dustScale = 1.0f;
 
+    private transient boolean hasTicker = false;
+
     public ParticleEmitterDecorationBlockBuilder(ResourceLocation i) {
         super(i);
-
         noCollision = true;
         hardness = 0;
         rotate = 0;
@@ -47,11 +54,24 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
         notSolid = true;
         renderType = "cutout";
         soundType = SoundType.GRASS;
-
         mapColor(MapColor.NONE);
     }
 
-    @Info("Sets the 'block item' of this block to an existing item")
+    @Info("Enable/disable per-tick ticker (default true)")
+    public ParticleEmitterDecorationBlockBuilder hasTicker(boolean enabled) {
+        this.hasTicker = enabled;
+        return this;
+    }
+
+    @Info("Sets base position inside block")
+    public ParticleEmitterDecorationBlockBuilder particleBase(double x, double y, double z) {
+        baseX = x;
+        baseY = y;
+        baseZ = z;
+        return this;
+    }
+
+    @Info("Attach existing item as block item")
     public ParticleEmitterDecorationBlockBuilder withPreexistingItem(ResourceLocation item) {
         itemBuilder = null;
         preexistingItem = Lazy.of(() -> RegistryInfo.ITEM.getValue(item));
@@ -59,31 +79,28 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
         return this;
     }
 
-    @Info("Rotates the default models by 45 degrees")
+    @Info("Rotate generated models by 45 degrees")
     public ParticleEmitterDecorationBlockBuilder notAxisAligned() {
         rotate = 45;
         return this;
     }
 
-    @Info("Sets the particle type emitted by the block (example: 'minecraft:bubble')")
+    @Info("Set particle type")
     public ParticleEmitterDecorationBlockBuilder particle(String id) {
         ResourceLocation rl = ResourceLocation.tryParse(id);
         particleType = Lazy.of(() -> {
             ParticleType<?> pt = RegistryInfo.PARTICLE_TYPE.getValue(rl);
             if (pt instanceof SimpleParticleType simple) {
+                if (id.equals("minecraft:dust"))
+                    useDustOptions = true;
                 return simple;
             }
             throw new IllegalArgumentException("Particle type '" + id + "' is not a SimpleParticleType");
         });
-
-        if (id.equals("minecraft:dust")) {
-            useDustOptions = true;
-        }
-
         return this;
     }
 
-    @Info("Sets the offset range for particles (default: 0.25, 1.0, 0.25)")
+    @Info("Set random spread ranges")
     public ParticleEmitterDecorationBlockBuilder particleOffset(double x, double y, double z) {
         offsetX = x;
         offsetY = y;
@@ -91,7 +108,7 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
         return this;
     }
 
-    @Info("Sets the particle velocity (default: 0.0, 0.07, 0.0)")
+    @Info("Set particle velocity")
     public ParticleEmitterDecorationBlockBuilder particleVelocity(double x, double y, double z) {
         velocityX = x;
         velocityY = y;
@@ -99,35 +116,33 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
         return this;
     }
 
-    @Info("Sets the number of particles emitted per tick (default: 1)")
+    @Info("Set particle count")
     public ParticleEmitterDecorationBlockBuilder particleCount(int count) {
         particleCount = count;
         return this;
     }
 
-    @Info("If true, particles are always visible in 512 blocks and on minimal visual setting. Normal is 32 blocks. (default: false)")
+    @Info("Always visible")
     public ParticleEmitterDecorationBlockBuilder particleForced(boolean forced) {
         particleForced = forced;
         return this;
     }
 
-    @Info("Set RGB color and scale for 'dust' particle type (float from 0.0 to 1.0)")
+    @Info("Dust RGB + scale")
     public ParticleEmitterDecorationBlockBuilder dustColor(float r, float g, float b, float scale) {
-        this.dustRed = r;
-        this.dustGreen = g;
-        this.dustBlue = b;
-        this.dustScale = scale;
+        dustRed = r;
+        dustGreen = g;
+        dustBlue = b;
+        dustScale = scale;
         return this;
     }
 
     @HideFromJS
     public VoxelShape getShape() {
-        if (customShape.isEmpty()) {
+        if (customShape.isEmpty())
             return ParticleEmitterDecorationBlock.DEFAULT_SHAPE;
-        }
-        if (cachedShape == null) {
+        if (cachedShape == null)
             cachedShape = BlockBuilder.createShape(customShape);
-        }
         return cachedShape;
     }
 
@@ -142,16 +157,24 @@ public class ParticleEmitterDecorationBlockBuilder extends ExtendedPropertiesBlo
 
     @Override
     public ParticleEmitterDecorationBlock createObject() {
-        return new ParticleEmitterDecorationBlock(
-                createProperties().offsetType(BlockBehaviour.OffsetType.XZ),
+        var props = createProperties().offsetType(BlockBehaviour.OffsetType.XZ);
+        var block = new ParticleEmitterDecorationBlock(
+                props,
                 getShape(),
                 itemSupplier(),
                 particleType,
+                baseX, baseY, baseZ,
                 offsetX, offsetY, offsetZ,
                 velocityX, velocityY, velocityZ,
                 particleCount,
                 particleForced,
                 useDustOptions,
-                dustRed, dustGreen, dustBlue, dustScale);
+                dustRed, dustGreen, dustBlue, dustScale,
+                hasTicker);
+        if (hasTicker) {
+            REGISTERED_BLOCKS.add(block);
+            ParticleEmitterBlockBuilder.REGISTERED_BLOCKS.add(block);
+        }
+        return block;
     }
 }


### PR DESCRIPTION
Updated particle emitters to be able to create assignable block entities. And cleaned them up a bit since they were kinda cluttered.
- If you want an emitter to form as a block entity you can add `.hasTicker(true)` to the register. BE's have multiple benefits; they can continue to create particles even if a player is out of range, and can have the frequency fully asjustable.
- You can now adjust the frequency of the random ticks with `.emitDelay(int)`. Settings the int to 0 will have particles appear every tick. The higher the number the longer the delay between random ticks. Essentially it creates a range, where a random number is picked in that range. The top end of the range is the sum of `emitDelay + 1`. Non block entities dont really get affected by this. Since the way regular blocks are ticked is controlled by an internal bernoulli distribution.
- You can now set the initial spawning point of the particles instead of them always spawning from the center of the block by adding `.particleBase(x, y, z)` to the register. For example, `.particleBase(0.5, 10.0, 0.5)` spawns the particle in the center of the block on the x/z but 10 blocks up on the y axis.

I will update the wiki tonight.