### PR TITLE
Mixin to fix /reload

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GregTechKubeJSPluginMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GregTechKubeJSPluginMixin.java
@@ -1,0 +1,26 @@
+package su.terrafirmagreg.core.mixins.common.gtceu;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.api.recipe.lookup.RecipeAdditionHandler;
+import com.gregtechceu.gtceu.integration.kjs.GregTechKubeJSPlugin;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+/**
+ * Fixes GTRecipeType.categoryMap not being cleared on /reload, causing stale EMI entries.
+ * Remove this mixin with the next release of GT (after 7.5.2)
+ */
+@Mixin(value = GregTechKubeJSPlugin.class, remap = false)
+public abstract class GregTechKubeJSPluginMixin {
+
+    @WrapOperation(method = "injectRuntimeRecipes", at = @At(value = "INVOKE", target = "Lcom/gregtechceu/gtceu/api/recipe/lookup/RecipeAdditionHandler;beginStaging()V"))
+    private void tfg$clearCategoryMapBeforeStaging(RecipeAdditionHandler handler, Operation<Void> original,
+            @Local(name = "gtRecipeType") GTRecipeType gtRecipeType) {
+        gtRecipeType.getCategoryMap().clear();
+        original.call(handler);
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -82,6 +82,7 @@
         "common.gtceu.GTCleanroomMixin",
         "common.gtceu.GTMachineUtilsMixin",
         "common.gtceu.GTMultiMachinesMixin",
+        "common.gtceu.GregTechKubeJSPluginMixin",
         "common.gtceu.GTRecipeTypesMixin",
         "common.gtceu.GTRecipeWidgetMixin",
         "common.gtceu.GTToolTypeMixin",


### PR DESCRIPTION
Wipe categoryMap on reload so EMI loads new values on /reload

Temporary mixin to fix https://github.com/GregTechCEu/GregTech-Modern/pull/4683 until GT does a new release.