### PR TITLE
When sipping ad astra gas tanks, check which hand is used

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/GasTankItemMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/GasTankItemMixin.java
@@ -2,7 +2,14 @@ package su.terrafirmagreg.core.mixins.common.ad_astra;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.llamalad7.mixinextras.sugar.Local;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
 import earth.terrarium.adastra.common.items.GasTankItem;
@@ -29,5 +36,15 @@ public abstract class GasTankItemMixin {
                         FluidConstants.fromMillibuckets(holder.getItem() == ModItems.GAS_TANK.get() ? 4000 : 8000),
                         1,
                         (t, f) -> f.is(TFGTags.Fluids.BreathableCompressedAir)));
+    }
+
+    /** Check which hand the used gas tank is in and update that hand. */
+    @Redirect(method = "onUseTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;setItem(ILnet/minecraft/world/item/ItemStack;)V"), remap = true)
+    private void fixOffHandTankWrite(Inventory inventory, int index, ItemStack updatedStack, @Local Player player) {
+        if (player.getUsedItemHand() == InteractionHand.OFF_HAND) {
+            inventory.offhand.set(0, updatedStack);
+        } else {
+            inventory.setItem(index, updatedStack);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3059

Ad astra didn't check which hand holds the used item so it would overwrite the selected inventory item whenever the offhand was used.

PR checks which hand is used and updates that item.