### PR TITLE
Fix GT drums not draining from Firmalife barrels when there's fluid in the drum.

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/FluidHelpersMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/FluidHelpersMixin.java
@@ -5,8 +5,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.minecraft.world.entity.Entity;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import su.terrafirmagreg.core.common.data.TFGFluids;
 
@@ -30,5 +35,19 @@ public class FluidHelpersMixin {
         if (entity.isEyeInFluidType(TFGFluids.MARS_WATER.type().get())) {
             cir.setReturnValue(true);
         }
+    }
+
+    /**
+     * Fix GT drums not draining from Firmalife barrels when there's fluid in the drum.
+     * This method handles fluid interaction between a block and an item.
+     * Previously it would only check if the item fluidholder was empty before transfering into the item.
+     * With this mixin it also checks if the block fluidholder is full.
+     */
+    @ModifyExpressionValue(method = "transferBetweenBlockHandlerAndItem", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fluids/FluidStack;isEmpty()Z"))
+    private static boolean tfg$transferBetweenBlockHandlerAndItem(
+            boolean isEmpty,
+            @Local(argsOnly = true) IFluidHandler blockHandler,
+            @Local FluidStack aggressiveDrained) {
+        return isEmpty || blockHandler.fill(aggressiveDrained, IFluidHandler.FluidAction.SIMULATE) <= 0;
     }
 }


### PR DESCRIPTION
## What is the new behavior?
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2835
Fix GT drums not draining from Firmalife barrels when there's fluid in the drum.

## Implementation Details
The mixin method handles fluid interaction between a block and an item. Previously it would only check if the item fluidholder was empty before transfering from the barrel to the item. With this mixin it also checks if the block fluidholder is full, and if so, it'll try to transfer fluid from the block to the item instead.

## Outcome
You can rightclick a barrel with a drum to drain fluid into it. If the barrel is full, the fluid will go the other way.

## Additional Information
We can remove this mixin if https://github.com/TerraFirmaCraft/TerraFirmaCraft/pull/3454 gets merged and released.