### PR TITLE
Fix runData hang

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/kubejs/MiscForgeHelperMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/kubejs/MiscForgeHelperMixin.java
@@ -1,0 +1,24 @@
+package su.terrafirmagreg.core.mixins.common.kubejs;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import net.minecraftforge.data.loading.DatagenModLoader;
+
+import dev.latvian.mods.kubejs.platform.forge.MiscForgeHelper;
+
+@Mixin(value = MiscForgeHelper.class, remap = false)
+public class MiscForgeHelperMixin {
+
+    /**
+     * @author Mqrius
+     * @reason Fix Forge bug where ModLoader.isDataGenRunning() always returns false;
+     * DatagenModLoader.isRunningDataGen() works fine.
+     * In non-datagen contexts kjs will make a threadpool that exits when minecraft exits.
+     * For datagen minecraft never exits properly so the thread stays around and the task never exits.
+     */
+    @Overwrite
+    public boolean isDataGen() {
+        return DatagenModLoader.isRunningDataGen();
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -70,6 +70,7 @@
         "common.firmalife.MixinGreenhousePortBlock",
         "common.flywheel.AnimatedBlazeBurnerMixin",
         "common.forge.CapabilityProviderMixin",
+        "common.kubejs.MiscForgeHelperMixin",
         "common.forge.ForgeConfigSpecMixin",
         "common.grappling_hook.AirFrictionControllerMixin",
         "common.grappling_hook.GrappleControllerMixin",


### PR DESCRIPTION
In non-datagen contexts KubeJS will make a threadpool that shuts down when minecraft shuts down. For datagen minecraft never exits properly so the thread stays around and the task never exits.

KubeJS will check if it's in a datagen context by calling ModLoader.isDataGenRunning(). Although that method exists, it always returns false.

There's also DatagenModLoader.isRunningDataGen(), which gives the correct answer. For some weird reason DatagenModLoader is _not_ a subclass of ModLoader, and also the method isn't called the same. Forge moment.

This mixin changes the isDataGen query to use DatagenModLoader's method instead.

Forge: 1.20.1-47.4.13
KubeJS: 2001.6.5-build.7

Fixes https://github.com/KubeJS-Mods/KubeJS/issues/480