### PR TITLE
Fix stacks of drums not being floaty

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/TFGCore.java
+++ b/src/main/java/su/terrafirmagreg/core/TFGCore.java
@@ -24,6 +24,8 @@ public final class TFGCore {
     public static final String NAME = "TerraFirmaGreg-Core";
     public static final Logger LOGGER = LoggerFactory.getLogger(NAME);
 
+    public static final boolean IS_APRIL_FIRST = java.time.LocalDate.now().getMonthValue() == 4 && java.time.LocalDate.now().getDayOfMonth() == 1;
+
     public static MaterialRegistry MATERIAL_REGISTRY;
     public static final GTRegistrate REGISTRATE = GTRegistrate.create(TFGCore.MOD_ID);
 

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
@@ -6,6 +6,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
+
 import net.dries007.tfc.common.TFCEffects;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -14,7 +16,9 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 import tfchotornot.EventHandler;
 
@@ -30,6 +34,12 @@ public class EventHandlerMixin {
         if (stack.is(TFGTags.Items.InsulatingContainer)) {
             ci.cancel();
         }
+    }
+
+    // Stacked fluid containers (count > 1) don't expose FLUID_HANDLER_ITEM capability, so query as a single-item stack
+    @ModifyReceiver(method = "onPlayerTick", require = 2, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getCapability(Lnet/minecraftforge/common/capabilities/Capability;)Lnet/minecraftforge/common/util/LazyOptional;", remap = false))
+    private static ItemStack tfg$normalizeStackCount(ItemStack stack, Capability<IFluidHandlerItem> cap) {
+        return stack.getCount() > 1 ? stack.copyWithCount(1) : stack;
     }
 
     // The first thing the mod does is check if the player has fire prot or resistance... which this should nullify.

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
@@ -1,8 +1,7 @@
 package su.terrafirmagreg.core.mixins.common.tfchotornot;
 
-import java.util.List;
-
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -29,19 +28,18 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import tfchotornot.EventHandler;
 
+import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.TFGTags;
 
 @Mixin(value = EventHandler.class, remap = false)
 public class EventHandlerMixin {
 
+    @Unique
     @SuppressWarnings("removal")
-    private static final List<TagKey<Fluid>> OIL_FLUID_TAGS = List.of(
-            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("firmalife", "oils")),
-            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil")),
-            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil_light")),
-            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil_medium")),
-            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil_heavy")));
-    private static final boolean IS_APRIL_FIRST = java.time.LocalDate.now().getMonthValue() == 4 && java.time.LocalDate.now().getDayOfMonth() == 1;
+    private static final TagKey<Fluid> GT_OILS = TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("tfg", "oils"));
+    @Unique
+    @SuppressWarnings("removal")
+    private static final TagKey<Fluid> FIRMALIFE_OILS = TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("firmalife", "oils"));
 
     // If the fluid is inside some sort of insulating container, cancel the effect
 
@@ -53,8 +51,8 @@ public class EventHandlerMixin {
         }
 
         // Oil floats on water O_O
-w        if (IS_APRIL_FIRST && level.isRainingAt(player.blockPosition().above())
-                && OIL_FLUID_TAGS.stream().anyMatch(tag -> Helpers.isFluid(fluidStack.getFluid(), tag))) {
+        if (TFGCore.IS_APRIL_FIRST && level.isRainingAt(player.blockPosition().above())
+                && (Helpers.isFluid(fluidStack.getFluid(), GT_OILS) || Helpers.isFluid(fluidStack.getFluid(), FIRMALIFE_OILS))) {
             player.addEffect(new MobEffectInstance(MobEffects.LEVITATION, 40, 0));
             ci.cancel();
         }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.ModifyReceiver;
 
 import net.dries007.tfc.common.TFCEffects;
+import net.dries007.tfc.util.EnvironmentHelpers;
 import net.dries007.tfc.util.Helpers;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
@@ -51,7 +52,7 @@ public class EventHandlerMixin {
         }
 
         // Oil floats on water O_O
-        if (TFGCore.IS_APRIL_FIRST && level.isRainingAt(player.blockPosition().above())
+        if (TFGCore.IS_APRIL_FIRST && EnvironmentHelpers.isRainingOrSnowing(level, player.blockPosition().above())
                 && (Helpers.isFluid(fluidStack.getFluid(), GT_OILS) || Helpers.isFluid(fluidStack.getFluid(), FIRMALIFE_OILS))) {
             player.addEffect(new MobEffectInstance(MobEffects.LEVITATION, 40, 0));
             ci.cancel();

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfchotornot/EventHandlerMixin.java
@@ -1,5 +1,7 @@
 package su.terrafirmagreg.core.mixins.common.tfchotornot;
 
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -9,6 +11,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.ModifyReceiver;
 
 import net.dries007.tfc.common.TFCEffects;
+import net.dries007.tfc.util.Helpers;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -16,9 +21,11 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import tfchotornot.EventHandler;
 
@@ -27,11 +34,28 @@ import su.terrafirmagreg.core.common.data.TFGTags;
 @Mixin(value = EventHandler.class, remap = false)
 public class EventHandlerMixin {
 
+    @SuppressWarnings("removal")
+    private static final List<TagKey<Fluid>> OIL_FLUID_TAGS = List.of(
+            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("firmalife", "oils")),
+            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil")),
+            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil_light")),
+            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil_medium")),
+            TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), new ResourceLocation("gtceu", "oil_heavy")));
+    private static final boolean IS_APRIL_FIRST = java.time.LocalDate.now().getMonthValue() == 4 && java.time.LocalDate.now().getDayOfMonth() == 1;
+
     // If the fluid is inside some sort of insulating container, cancel the effect
 
     @Inject(method = "applyEffectsFluid", at = @At("HEAD"), remap = false, cancellable = true)
     private static void tfg$applyEffectsFluid(ItemStack stack, FluidStack fluidStack, Player player, Level level, CallbackInfo ci) {
         if (stack.is(TFGTags.Items.InsulatingContainer)) {
+            ci.cancel();
+            return;
+        }
+
+        // Oil floats on water O_O
+w        if (IS_APRIL_FIRST && level.isRainingAt(player.blockPosition().above())
+                && OIL_FLUID_TAGS.stream().anyMatch(tag -> Helpers.isFluid(fluidStack.getFluid(), tag))) {
+            player.addEffect(new MobEffectInstance(MobEffects.LEVITATION, 40, 0));
             ci.cancel();
         }
     }


### PR DESCRIPTION
Stacked fluid containers (count > 1) don't expose FLUID_HANDLER_ITEM capability, so query as a single-item stack instead
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2814