### PR TITLE
Datagen Fixes

### DIFF
--- a/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/copper_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/copper_greenhouse_casing_4.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "tfg:block/casings/greenhouse/copper_greenhouse_casing_4"
+    }
+  }
+}

--- a/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/iron_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/iron_greenhouse_casing_4.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "tfg:block/casings/greenhouse/iron_greenhouse_casing_4"
+    }
+  }
+}

--- a/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/stainless_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/stainless_greenhouse_casing_4.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "tfg:block/casings/greenhouse/stainless_greenhouse_casing_4"
+    }
+  }
+}

--- a/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/treated_wood_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/blockstates/casings/greenhouse/treated_wood_greenhouse_casing_4.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "tfg:block/casings/greenhouse/treated_wood_greenhouse_casing_4"
+    }
+  }
+}

--- a/src/generated/resources/assets/tfg/models/block/casings/greenhouse/copper_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/block/casings/greenhouse/copper_greenhouse_casing_4.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "tfg:block/casings/greenhouse/copper_greenhouse_casing_4"
+  }
+}

--- a/src/generated/resources/assets/tfg/models/block/casings/greenhouse/iron_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/block/casings/greenhouse/iron_greenhouse_casing_4.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "tfg:block/casings/greenhouse/iron_greenhouse_casing_4"
+  }
+}

--- a/src/generated/resources/assets/tfg/models/block/casings/greenhouse/stainless_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/block/casings/greenhouse/stainless_greenhouse_casing_4.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "tfg:block/casings/greenhouse/stainless_greenhouse_casing_4"
+  }
+}

--- a/src/generated/resources/assets/tfg/models/block/casings/greenhouse/treated_wood_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/block/casings/greenhouse/treated_wood_greenhouse_casing_4.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "tfg:block/casings/greenhouse/treated_wood_greenhouse_casing_4"
+  }
+}

--- a/src/generated/resources/assets/tfg/models/item/casings/greenhouse/copper_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/item/casings/greenhouse/copper_greenhouse_casing_4.json
@@ -1,0 +1,3 @@
+{
+  "parent": "tfg:block/casings/greenhouse/copper_greenhouse_casing_4"
+}

--- a/src/generated/resources/assets/tfg/models/item/casings/greenhouse/iron_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/item/casings/greenhouse/iron_greenhouse_casing_4.json
@@ -1,0 +1,3 @@
+{
+  "parent": "tfg:block/casings/greenhouse/iron_greenhouse_casing_4"
+}

--- a/src/generated/resources/assets/tfg/models/item/casings/greenhouse/stainless_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/item/casings/greenhouse/stainless_greenhouse_casing_4.json
@@ -1,0 +1,3 @@
+{
+  "parent": "tfg:block/casings/greenhouse/stainless_greenhouse_casing_4"
+}

--- a/src/generated/resources/assets/tfg/models/item/casings/greenhouse/treated_wood_greenhouse_casing_4.json
+++ b/src/generated/resources/assets/tfg/models/item/casings/greenhouse/treated_wood_greenhouse_casing_4.json
@@ -1,0 +1,3 @@
+{
+  "parent": "tfg:block/casings/greenhouse/treated_wood_greenhouse_casing_4"
+}

--- a/src/generated/resources/assets/tfg/models/item/fish_roe.json
+++ b/src/generated/resources/assets/tfg/models/item/fish_roe.json
@@ -1,8 +1,9 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "tfg:item/progenitor_cells_0",
-    "layer1": "tfg:item/progenitor_cells_1",
-    "layer2": "tfg:item/progenitor_cells_2"
+    "layer0": "tfg:item/fish_roe_0",
+    "layer1": "tfg:item/fish_roe_0",
+    "layer2": "tfg:item/fish_roe_1",
+    "layer3": "tfg:item/fish_roe_2"
   }
 }

--- a/src/generated/resources/assets/tfg/models/item/progenitor_cells.json
+++ b/src/generated/resources/assets/tfg/models/item/progenitor_cells.json
@@ -1,9 +1,8 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "tfg:item/fish_roe_0",
-    "layer1": "tfg:item/fish_roe_0",
-    "layer2": "tfg:item/fish_roe_1",
-    "layer3": "tfg:item/fish_roe_2"
+    "layer0": "tfg:item/progenitor_cells_0",
+    "layer1": "tfg:item/progenitor_cells_1",
+    "layer2": "tfg:item/progenitor_cells_2"
   }
 }

--- a/src/generated/resources/data/firmalife/tags/blocks/all_copper_greenhouse.json
+++ b/src/generated/resources/data/firmalife/tags/blocks/all_copper_greenhouse.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
-    "tfg:casings/greenhouse/copper_greenhouse_casing_3"
+    "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/firmalife/tags/blocks/all_iron_greenhouse.json
+++ b/src/generated/resources/data/firmalife/tags/blocks/all_iron_greenhouse.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
-    "tfg:casings/greenhouse/iron_greenhouse_casing_3"
+    "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/firmalife/tags/blocks/all_treated_wood_greenhouse.json
+++ b/src/generated/resources/data/firmalife/tags/blocks/all_treated_wood_greenhouse.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_0",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
-    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3"
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/firmalife/tags/blocks/greenhouse.json
+++ b/src/generated/resources/data/firmalife/tags/blocks/greenhouse.json
@@ -4,17 +4,21 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/firmalife/tags/blocks/greenhouse_full_walls.json
+++ b/src/generated/resources/data/firmalife/tags/blocks/greenhouse_full_walls.json
@@ -4,17 +4,21 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/firmalife/tags/blocks/stainless_steel_greenhouse.json
+++ b/src/generated/resources/data/firmalife/tags/blocks/stainless_steel_greenhouse.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/gtceu/tags/blocks/mineable/pickaxe_or_wrench.json
+++ b/src/generated/resources/data/gtceu/tags/blocks/mineable/pickaxe_or_wrench.json
@@ -32,18 +32,22 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4",
     "tfg:casings/sterling_silver_casing"
   ]
 }

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_0",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
-    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3"
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -4,13 +4,16 @@
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfc/tags/blocks/mineable_with_glass_saw.json
+++ b/src/generated/resources/data/tfc/tags/blocks/mineable_with_glass_saw.json
@@ -5,17 +5,21 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/copper_greenhouse_casing_4.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/copper_greenhouse_casing_4.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "tfg:casings/greenhouse/copper_greenhouse_casing_4"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "tfg:blocks/casings/greenhouse/copper_greenhouse_casing_4"
+}

--- a/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/iron_greenhouse_casing_4.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/iron_greenhouse_casing_4.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "tfg:casings/greenhouse/iron_greenhouse_casing_4"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "tfg:blocks/casings/greenhouse/iron_greenhouse_casing_4"
+}

--- a/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/stainless_greenhouse_casing_4.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/stainless_greenhouse_casing_4.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "tfg:blocks/casings/greenhouse/stainless_greenhouse_casing_4"
+}

--- a/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/treated_wood_greenhouse_casing_4.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/casings/greenhouse/treated_wood_greenhouse_casing_4.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "tfg:blocks/casings/greenhouse/treated_wood_greenhouse_casing_4"
+}

--- a/src/generated/resources/data/tfg/tags/blocks/casings.json
+++ b/src/generated/resources/data/tfg/tags/blocks/casings.json
@@ -28,18 +28,22 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4",
     "tfg:casings/sterling_silver_casing"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/blocks/copper_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/blocks/copper_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
-    "tfg:casings/greenhouse/copper_greenhouse_casing_3"
+    "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/blocks/iron_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/blocks/iron_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
-    "tfg:casings/greenhouse/iron_greenhouse_casing_3"
+    "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/blocks/stainless_steel_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/blocks/stainless_steel_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/blocks/treated_wood_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/blocks/treated_wood_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_0",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
-    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3"
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/items/all_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/items/all_greenhouse_casings.json
@@ -4,17 +4,21 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/items/casings.json
+++ b/src/generated/resources/data/tfg/tags/items/casings.json
@@ -28,18 +28,22 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4",
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
     "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4",
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
     "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4",
     "tfg:casings/sterling_silver_casing"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/items/copper_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/items/copper_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/copper_greenhouse_casing_0",
     "tfg:casings/greenhouse/copper_greenhouse_casing_1",
     "tfg:casings/greenhouse/copper_greenhouse_casing_2",
-    "tfg:casings/greenhouse/copper_greenhouse_casing_3"
+    "tfg:casings/greenhouse/copper_greenhouse_casing_3",
+    "tfg:casings/greenhouse/copper_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/items/iron_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/items/iron_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/iron_greenhouse_casing_0",
     "tfg:casings/greenhouse/iron_greenhouse_casing_1",
     "tfg:casings/greenhouse/iron_greenhouse_casing_2",
-    "tfg:casings/greenhouse/iron_greenhouse_casing_3"
+    "tfg:casings/greenhouse/iron_greenhouse_casing_3",
+    "tfg:casings/greenhouse/iron_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/items/stainless_steel_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/items/stainless_steel_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/stainless_greenhouse_casing_0",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_1",
     "tfg:casings/greenhouse/stainless_greenhouse_casing_2",
-    "tfg:casings/greenhouse/stainless_greenhouse_casing_3"
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_3",
+    "tfg:casings/greenhouse/stainless_greenhouse_casing_4"
   ]
 }

--- a/src/generated/resources/data/tfg/tags/items/treated_wood_greenhouse_casings.json
+++ b/src/generated/resources/data/tfg/tags/items/treated_wood_greenhouse_casings.json
@@ -3,6 +3,7 @@
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_0",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_1",
     "tfg:casings/greenhouse/treated_wood_greenhouse_casing_2",
-    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3"
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_3",
+    "tfg:casings/greenhouse/treated_wood_greenhouse_casing_4"
   ]
 }

--- a/src/main/java/su/terrafirmagreg/core/common/CommonProxy.java
+++ b/src/main/java/su/terrafirmagreg/core/common/CommonProxy.java
@@ -65,6 +65,7 @@ public class CommonProxy {
         TFGEffects.EFFECTS.register(bus);
         TFGRecipeTypes.RECIPE_TYPES.register(bus);
         TFGRecipeSerializers.RECIPE_SERIALIZERS.register(bus);
+        TFGEvents.register();
 
         TFGBrain.MEMORY_TYPES.register(bus);
         TFGBrain.SENSOR_TYPES.register(bus);

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGBlocks.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGBlocks.java
@@ -731,7 +731,7 @@ public final class TFGBlocks {
     public static BlockEntry<Block>[] createGreenhouseCasings(String tier, List<TagKey<Block>> blockTags, List<TagKey<Item>> itemTags) {
         List<BlockEntry<ConnectedGlassBlock>> casings = new ArrayList<>();
 
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 5; i++) {
             String blockId = "casings/greenhouse/%s_greenhouse_casing_%s".formatted(tier, i);
             var blockBuilder = TFGCore.REGISTRATE.block(blockId, ConnectedGlassBlock::new)
                     .initialProperties(() -> Blocks.GLASS)

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGEvents.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGEvents.java
@@ -1,0 +1,12 @@
+package su.terrafirmagreg.core.common.data;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import su.terrafirmagreg.core.common.data.events.*;
+
+public class TFGEvents {
+
+    public static void register() {
+        MinecraftForge.EVENT_BUS.register(new HarvesterEvent());
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGItems.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGItems.java
@@ -52,6 +52,7 @@ public class TFGItems {
             .register();
 
     public static final ItemEntry<TrowelItem> TROWEL = TFGCore.REGISTRATE.item("trowel", TrowelItem::new)
+            .properties(p -> p.stacksTo(1))
             .setData(ProviderType.ITEM_MODEL, NonNullBiConsumer.noop())
             .register();
 

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGItems.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGItems.java
@@ -66,11 +66,11 @@ public class TFGItems {
             .register();
 
     public static final ItemEntry<ProgenitorCellsItem> PROGENITOR_CELLS = TFGCore.REGISTRATE.item("progenitor_cells", ProgenitorCellsItem::new)
-            .model(ModelUtils.layeredItemModel(TFGCore.id("item/fish_roe_0"), TFGCore.id("item/fish_roe_0"), TFGCore.id("item/fish_roe_1"), TFGCore.id("item/fish_roe_2")))
+            .model(ModelUtils.layeredItemModel(TFGCore.id("item/progenitor_cells_0"), TFGCore.id("item/progenitor_cells_1"), TFGCore.id("item/progenitor_cells_2")))
             .register();
 
     public static final ItemEntry<FishRoeItem> FISH_ROE = TFGCore.REGISTRATE.item("fish_roe", FishRoeItem::new)
-            .model(ModelUtils.layeredItemModel(TFGCore.id("item/progenitor_cells_0"), TFGCore.id("item/progenitor_cells_1"), TFGCore.id("item/progenitor_cells_2")))
+            .model(ModelUtils.layeredItemModel(TFGCore.id("item/fish_roe_0"), TFGCore.id("item/fish_roe_0"), TFGCore.id("item/fish_roe_1"), TFGCore.id("item/fish_roe_2")))
             .register();
 
     public static final ItemEntry<ForgeSpawnEggItem> MOON_RABBIT_EGG = registerSpawnEgg(TFGEntities.MOON_RABBIT, 15767516, 9756658);

--- a/src/main/java/su/terrafirmagreg/core/common/data/events/HarvesterEvent.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/events/HarvesterEvent.java
@@ -2,11 +2,13 @@ package su.terrafirmagreg.core.common.data.events;
 
 import java.util.*;
 
+import com.eerussianguy.firmalife.common.blockentities.LargePlanterBlockEntity;
+import com.eerussianguy.firmalife.common.blocks.greenhouse.LargePlanterBlock;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -17,18 +19,29 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.items.ItemHandlerHelper;
 
-import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.TFGTags;
 import su.terrafirmagreg.core.config.TFGConfig;
 
-@Mod.EventBusSubscriber(modid = TFGCore.MOD_ID)
+/**
+ * Handles the harvester tool right-click event for mass harvesting blocks tagged as harvestable.
+ */
 public class HarvesterEvent {
 
     private static final TagKey<Item> HARVESTER_ITEM_TAG = TFGTags.Items.Harvester;
     private static final TagKey<Block> HARVESTABLE_BLOCK_TAG = TFGTags.Blocks.HarvesterHarvestable;
 
+    /**
+     * Handles the right-click block event for the harvester tool.
+     * <p>
+     * If the player is holding a harvester item and right-clicks a harvestable block,
+     * performs a breadth first search to harvest all connected harvestable blocks within the configured radius.
+     * <p>
+     * For LargePlanterBlock, uses the Firmalife API to harvest each slot. For other blocks, simulates a use action.
+     *
+     * @param event The right-click block event.
+     */
     @SubscribeEvent
     public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
 
@@ -75,7 +88,14 @@ public class HarvesterEvent {
                     current,
                     false);
 
-            InteractionResult result = state.use(level, player, hand, hit);
+            if (state.getBlock() instanceof LargePlanterBlock
+                    && level.getBlockEntity(current) instanceof LargePlanterBlockEntity planter) {
+                for (int slot = 0; slot < planter.slots(); slot++) {
+                    LargePlanterBlock.takeSlot(level, planter, slot, i -> ItemHandlerHelper.giveItemToPlayer(player, i));
+                }
+            } else {
+                state.use(level, player, hand, hit);
+            }
 
             // Iterates through connected and diagonal neighbors
             for (int dx = -1; dx <= 1; dx++) {

--- a/src/main/java/su/terrafirmagreg/core/common/data/items/TrowelItem.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/items/TrowelItem.java
@@ -1,19 +1,16 @@
 package su.terrafirmagreg.core.common.data.items;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Random;
 
 import org.jetbrains.annotations.NotNull;
 
-import net.dries007.tfc.common.blocks.rock.Rock;
-import net.dries007.tfc.common.blocks.soil.SandBlockType;
+import com.therighthon.rnr.common.recipe.BlockModRecipe;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionResult;
@@ -24,81 +21,38 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraftforge.registries.ForgeRegistries;
 
+import su.terrafirmagreg.core.utils.TFGModsResolver;
+
+/**
+ * The TrowelItem allows players to place random blocks from their hotbar or, if the RnR mod is loaded,
+ * to use RnR road recipes on base course blocks using items from the hotbar.
+ */
+@SuppressWarnings("deprecation")
 public class TrowelItem extends Item {
-    public TrowelItem(Properties properties) {
-        super(properties.durability(1026));
+
+    public TrowelItem(Properties props) {
+        super(props);
     }
 
-    // Maps for RNR block replacing.
-    public static Map<ResourceLocation, ResourceLocation> createBlockMapping() {
-        Map<ResourceLocation, ResourceLocation> map = new HashMap<>();
-
-        // Gets enums from TFC and turns into a sring for the maps.
-        List<String> sandstone_colors = Arrays.stream(SandBlockType.values())
-                .map(SandBlockType -> SandBlockType.name().toLowerCase(Locale.ROOT))
-                .toList();
-
-        List<String> rocks = Arrays.stream(Rock.values())
-                .map(rock -> rock.name().toLowerCase(Locale.ROOT))
-                .toList();
-
-        // Sandstone
-        for (String sandstone_color : sandstone_colors) {
-            map.put(
-                    ResourceLocation.fromNamespaceAndPath("rnr", "flagstone/" + sandstone_color + "_sandstone"),
-                    ResourceLocation.fromNamespaceAndPath("rnr", sandstone_color + "_sandstone_flagstones"));
-        }
-        // Flagstones
-        for (String flagstone_rock : rocks) {
-            map.put(
-                    ResourceLocation.fromNamespaceAndPath("rnr", "flagstone/" + flagstone_rock),
-                    ResourceLocation.fromNamespaceAndPath("rnr", "rock/flagstones/" + flagstone_rock));
-        }
-        // Gravel
-        for (String gravel_rock : rocks) {
-            map.put(
-                    ResourceLocation.fromNamespaceAndPath("rnr", "gravel_fill/" + gravel_rock),
-                    ResourceLocation.fromNamespaceAndPath("rnr", "rock/gravel_road/" + gravel_rock));
-        }
-        // Cobble
-        for (String cobble_rock : rocks) {
-            map.put(
-                    ResourceLocation.fromNamespaceAndPath("tfc", "rock/loose/" + cobble_rock),
-                    ResourceLocation.fromNamespaceAndPath("rnr", "rock/cobbled_road/" + cobble_rock));
-        }
-        for (String mossy_cobble_rock : rocks) {
-            map.put(
-                    ResourceLocation.fromNamespaceAndPath("tfc", "rock/mossy_loose/" + mossy_cobble_rock),
-                    ResourceLocation.fromNamespaceAndPath("rnr", "rock/cobbled_road/" + mossy_cobble_rock));
-        }
-        // Sett Bricks
-        for (String brick_rock : rocks) {
-            map.put(
-                    ResourceLocation.fromNamespaceAndPath("tfc", "brick/" + brick_rock),
-                    ResourceLocation.fromNamespaceAndPath("rnr", "rock/sett_road/" + brick_rock));
-        }
-        // Hoggin
-        map.put(
-                ResourceLocation.fromNamespaceAndPath("rnr", "hoggin_mix"),
-                ResourceLocation.fromNamespaceAndPath("rnr", "hoggin"));
-        // Brick
-        map.put(
-                ResourceLocation.fromNamespaceAndPath("minecraft", "brick"),
-                ResourceLocation.fromNamespaceAndPath("rnr", "brick_road"));
-
-        return map;
-    }
-
+    /**
+     * Called when the player uses the trowel on a block. If the RnR mod is loaded and the clicked block is
+     * base course, it attempts to apply a matching RnR BlockModRecipe using a hotbar item. Otherwise, places
+     * a random block from the player's hotbar.
+     *
+     * @param context The use context, including player, world, and target block information.
+     * @return The result of the interaction.
+     */
     @Override
     public @NotNull InteractionResult useOn(UseOnContext context) {
         Level level = context.getLevel();
         if (level.isClientSide())
             return InteractionResult.SUCCESS;
+
+        if (!(level instanceof ServerLevel))
+            return InteractionResult.PASS;
 
         Player player = context.getPlayer();
         if (player == null)
@@ -110,51 +64,37 @@ public class TrowelItem extends Item {
         BlockState clickedState = level.getBlockState(targetPos);
         ResourceLocation clickedBlockId = clickedState.getBlock().builtInRegistryHolder().key().location();
 
-        Map<ResourceLocation, ResourceLocation> blockMapping = createBlockMapping();
-
-        // Exception for rnr roads.
-        if (clickedBlockId.toString().equals("rnr:base_course")) {
-            List<ItemStack> validStacks = new ArrayList<>();
-            // Randomly chooses a spot in the hotbar.
+        // RNR road exception. Use BlockModRecipe to find a matching recipe.
+        if (TFGModsResolver.RNR.isLoaded() && clickedBlockId.toString().equals("rnr:base_course")) {
+            List<HotbarEntry> validEntries = new ArrayList<>();
             for (int i = 0; i < 9; i++) {
                 ItemStack hotbarStack = player.getInventory().getItem(i);
                 if (!hotbarStack.isEmpty()) {
-                    ResourceLocation itemId = ForgeRegistries.ITEMS.getKey(hotbarStack.getItem());
-                    if (itemId != null && blockMapping.containsKey(itemId)) {
-                        validStacks.add(hotbarStack);
+                    ItemStack oneStack = hotbarStack.copy();
+                    oneStack.setCount(1);
+                    BlockModRecipe recipe = BlockModRecipe.getRecipe(clickedState, oneStack);
+                    if (recipe != null && recipe.getOutputBlock() != null && recipe.getOutputBlock() != clickedState) {
+                        validEntries.add(new HotbarEntry(i, hotbarStack, recipe));
                     }
                 }
             }
 
-            if (validStacks.isEmpty())
+            if (validEntries.isEmpty())
                 return InteractionResult.PASS;
 
-            ItemStack randomStack = validStacks.get(new Random().nextInt(validStacks.size()));
-            ResourceLocation itemId = ForgeRegistries.ITEMS.getKey(randomStack.getItem());
-            ResourceLocation resultBlockId = blockMapping.get(itemId);
-            Block resultBlock = ForgeRegistries.BLOCKS.getValue(resultBlockId);
+            HotbarEntry chosen = validEntries.get(new Random().nextInt(validEntries.size()));
+            BlockState newState = chosen.recipe.getOutputBlock();
 
-            if (resultBlock != null) {
-                // Updates state.
-                BlockState newState = resultBlock.defaultBlockState();
-                level.setBlock(targetPos, newState, 3);
-                level.updateNeighborsAt(targetPos, resultBlock);
+            level.setBlock(targetPos, newState, 3);
+            level.updateNeighborsAt(targetPos, newState.getBlock());
 
-                // Plays sound when placing.
-                level.playSound(null, targetPos, SoundEvents.FLINTANDSTEEL_USE, SoundSource.BLOCKS, 1.0f, 0.4f);
+            level.playSound(null, targetPos, SoundEvents.FLINTANDSTEEL_USE, SoundSource.BLOCKS, 1.0f, 0.4f);
 
-                // Decreases item count unless in creative.
-                if (!player.isCreative()) {
-                    randomStack.shrink(1);
-                }
-
-                // Damages the tool, or breaks it if at 0.
-                stack.hurtAndBreak(1, player, p -> p.broadcastBreakEvent(context.getHand()));
-
-                return InteractionResult.SUCCESS;
+            if (!player.isCreative() && Boolean.TRUE.equals(chosen.recipe.consumesItem())) {
+                chosen.stack.shrink(1);
             }
 
-            return InteractionResult.FAIL;
+            return InteractionResult.SUCCESS;
         }
 
         // Normal block behavior.
@@ -197,11 +137,16 @@ public class TrowelItem extends Item {
             randomStack.shrink(1);
         }
 
-        // Only damage the trowel if the block was placed
-        if (result.consumesAction() && !player.isCreative()) {
-            stack.hurtAndBreak(1, player, p -> p.broadcastBreakEvent(context.getHand()));
-        }
-
         return result;
+    }
+
+    /**
+     * Represents a hotbar entry containing the slot index, item stack, and associated BlockModRecipe.
+     *
+     * @param slot   The hotbar slot index.
+     * @param stack  The item stack in the slot.
+     * @param recipe The matching BlockModRecipe for this stack and block state.
+     */
+    private record HotbarEntry(int slot, ItemStack stack, BlockModRecipe recipe) {
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/utils/TFGModsResolver.java
+++ b/src/main/java/su/terrafirmagreg/core/utils/TFGModsResolver.java
@@ -11,7 +11,8 @@ public enum TFGModsResolver {
     CREATE("create"),
     TFC_AMBIENTAL("tfcambiental"),
     TFC("tfc"),
-    GRAPPLEMOD("grapplemod");
+    GRAPPLEMOD("grapplemod"),
+    RNR("rnr");
 
     private final String name;
     private Boolean modLoaded;


### PR DESCRIPTION
- Fixed missing greenhouse casings from datagen
- Fixed wrong item textures for fish roe and proginator cells
- Fixed events bus being missing
- Added firmalife planter support for harvest baskets
- Updated the trowels to use the RNR recipes instead of manual mappings. And made them unbreakable.

Closes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3078
