### PR TITLE
Fix offhand lag

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/TFGMixinPlugin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/TFGMixinPlugin.java
@@ -18,21 +18,43 @@ public class TFGMixinPlugin implements IMixinConfigPlugin {
     private static final String SPECIES_MIXIN_JSON = "species.mixins.json";
     private static final String SPECIES_BLOCK_ENTITY_TYPE_MIXIN = "com.ninni.species.mixin.BlockEntityTypeMixin";
 
+    private static final String AAAPARTICLES_MIXIN_JSON = "aaa_particles.mixins.json";
+    private static final String AAAPARTICLES_GAME_RENDERER_MIXIN = "mod.chloeprime.aaaparticles.mixin.client.MixinGameRenderer";
+    private static final String AAAPARTICLES_ITEM_IN_HAND_RENDERER_MIXIN = "mod.chloeprime.aaaparticles.mixin.client.MixinItemInHandRenderer";
+
     /**
      * acceptTargets fires once after all configs have been collected but before any have been applied,
      * so we can safely modify the mixin configs at this point.
      */
     @Override
     public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+        String currentMixin = null;
+        String currentConfig = null;
+
         try {
             for (Object config : getPendingConfigs()) {
-                // Remove BlockEntityTypeMixin from the species config avoiding
-                //  CIR allocation on every block entity tick for 0.5 ms/tick
-                if (SPECIES_MIXIN_JSON.equals(getConfigName(config)))
-                    removeMixin(config, SPECIES_BLOCK_ENTITY_TYPE_MIXIN);
+                currentConfig = getConfigName(config);
+
+                if (SPECIES_MIXIN_JSON.equals(currentConfig)) {
+                    // Remove BlockEntityTypeMixin from the species config avoiding
+                    //  CIR allocation on every block entity tick for 0.5 ms/tick
+                    currentMixin = SPECIES_BLOCK_ENTITY_TYPE_MIXIN;
+                    removeMixin(config, currentMixin);
+                }
+
+                if (AAAPARTICLES_MIXIN_JSON.equals(currentConfig)) {
+                    // Remove hand rendering mixins from AAA Particles
+                    // Only the sandworm mod uses AAA Particles and not for the hands
+                    // Causes lag spikes when switching items
+                    currentMixin = AAAPARTICLES_GAME_RENDERER_MIXIN;
+                    removeMixin(config, currentMixin);
+                    currentMixin = AAAPARTICLES_ITEM_IN_HAND_RENDERER_MIXIN;
+                    removeMixin(config, currentMixin);
+                }
             }
         } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Failed to remove " + SPECIES_BLOCK_ENTITY_TYPE_MIXIN + " from " + SPECIES_MIXIN_JSON, e);
+            throw new RuntimeException("Failed to remove " + currentMixin + " from " + currentConfig, e);
         }
     }
 


### PR DESCRIPTION
## What is the new behavior?
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3193

## Implementation Details
Prevent AAAParticles hand renderer mixins from applying. We don't use the hand rendering for anything so we don't need it.

What's actually happening is kinda funny.
AAAParticles checks with its registries if anything wants to emit particles when you have something in a hand.
It tries to account for lag, so it checks, hey, when did we last do this? And if it's longer ago it runs through its registries more often to maybe spawn more particles.
However, this check doesn't actually run if there's nothing in your (off)hand... so the moment you put something in your offhand, minutes later, it's like "wow we haven't spawned any particles in several minutes! Let's run through my registries a bazillion times cos maybe we need to spawn a bazillion particles!"

Of course TFG doesn't have any particles that spawn from your hands, but that doesn't really matter, it still creates a bazillion particle spawning contexts.

It's also clearer now why some people experience this a lot and some people don't. If you usually have something in your offhand, you won't experience this lag. And also after the first time it happens it's fine for a while.
You can probably also experience it in your mainhand if you usually keep that empty

## Outcome
AAA Particles doesn't touch hand rendering in any way

## Additional Information
AAA Particles is only used for the sandworm mod, and only for the dirt splash when it enters or leaves the Earth. As far as I can tell there's no other places that use it.
Dirt splash still works cos that's a different code path.

Also reported upstream: https://github.com/ChloePrime/AAAParticles/issues/67