### PR TITLE
Add /tfg debug dump_recipes, dump_recipes_detailed, dump_pipe_recipes

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
@@ -3,6 +3,7 @@ package su.terrafirmagreg.core.common;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -14,9 +15,15 @@ import su.terrafirmagreg.core.common.data.capabilities.LargeEggCapability;
 import su.terrafirmagreg.core.common.data.capabilities.LargeEggHandler;
 import su.terrafirmagreg.core.network.TFGNetworkHandler;
 import su.terrafirmagreg.core.network.packet.FuelSyncPacket;
+import su.terrafirmagreg.core.utils.commands.TFGCommands;
 
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID)
 public final class ForgeCommonEventListener {
+
+    @SubscribeEvent
+    public static void registerCommands(RegisterCommandsEvent event) {
+        TFGCommands.register(event.getDispatcher());
+    }
 
     @SubscribeEvent
     public static void attachItemCapabilities(AttachCapabilitiesEvent<ItemStack> event) {

--- a/src/main/java/su/terrafirmagreg/core/utils/commands/DebugRecipeDump.java
+++ b/src/main/java/su/terrafirmagreg/core/utils/commands/DebugRecipeDump.java
@@ -1,0 +1,172 @@
+package su.terrafirmagreg.core.utils.commands;
+
+import static net.minecraft.commands.Commands.literal;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.stream.JsonWriter;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeManager;
+
+public class DebugRecipeDump {
+
+    @SuppressWarnings("removal")
+    private static final List<TagKey<Item>> PIPE_TAGS = List.of(
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "tiny_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "small_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "normal_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "large_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "huge_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "quadruple_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "nonuple_fluid_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "small_item_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "normal_item_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "large_item_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "huge_item_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "small_restrictive_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "normal_restrictive_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "large_restrictive_pipes")),
+            TagKey.create(Registries.ITEM, new ResourceLocation("forge", "huge_restrictive_pipes")));
+
+    public static void register(LiteralArgumentBuilder<CommandSourceStack> debug) {
+        debug.then(literal("dump_recipes")
+                .executes(c -> dumpRecipes(c.getSource(), false)));
+        debug.then(literal("dump_recipes_detailed")
+                .executes(c -> dumpRecipes(c.getSource(), true)));
+        debug.then(literal("dump_pipe_recipes")
+                .executes(c -> dumpPipeRecipes(c.getSource())));
+    }
+
+    private static int dumpRecipes(CommandSourceStack source, boolean detailed) {
+        var registryAccess = source.getServer().registryAccess();
+        RecipeManager rm = source.getServer().getRecipeManager();
+
+        List<Recipe<?>> sorted = new ArrayList<>(rm.getRecipes());
+        sorted.sort(Comparator.comparing(r -> r.getId().toString()));
+
+        Path out = Path.of(detailed ? "recipe_dump_detailed.json" : "recipe_dump.json");
+
+        try (BufferedWriter bw = Files.newBufferedWriter(out);
+                JsonWriter jw = new JsonWriter(bw)) {
+
+            jw.setIndent("  ");
+            jw.beginArray();
+
+            if (detailed) {
+                for (Recipe<?> r : sorted) {
+                    jw.beginObject();
+                    jw.name("id").value(r.getId().toString());
+                    jw.name("type").value(r.getType().toString());
+                    jw.name("output").value(r.getResultItem(registryAccess).toString());
+                    jw.name("ingredients").beginArray();
+                    for (var ingredient : r.getIngredients()) {
+                        jw.beginArray();
+                        for (var stack : ingredient.getItems()) {
+                            jw.value(stack.getItem().toString());
+                        }
+                        jw.endArray();
+                    }
+                    jw.endArray();
+                    jw.endObject();
+                }
+            } else {
+                for (Recipe<?> r : sorted) {
+                    jw.value(r.getId().toString());
+                }
+            }
+
+            jw.endArray();
+        } catch (IOException e) {
+            source.sendFailure(Component.literal("Failed to write recipe dump: " + e.getMessage()));
+            return 0;
+        }
+
+        source.sendSuccess(() -> Component.literal(
+                "Dumped " + sorted.size() + " recipes to " + out.toAbsolutePath()), true);
+        return sorted.size();
+    }
+
+    private static int dumpPipeRecipes(CommandSourceStack source) {
+        var registryAccess = source.getServer().registryAccess();
+        var itemRegistry = registryAccess.registryOrThrow(Registries.ITEM);
+
+        Set<Item> pipeItems = new HashSet<>();
+        for (var tagKey : PIPE_TAGS) {
+            itemRegistry.getTagOrEmpty(tagKey).forEach(holder -> pipeItems.add(holder.value()));
+        }
+
+        if (pipeItems.isEmpty()) {
+            source.sendFailure(Component.literal("No pipe items found"));
+            return 0;
+        }
+
+        List<Recipe<?>> sorted = new ArrayList<>(source.getServer().getRecipeManager().getRecipes());
+        sorted.sort(Comparator.comparing(r -> r.getId().toString()));
+
+        Path out = Path.of("recipe_dump_pipes.json");
+        int count = 0;
+
+        try (BufferedWriter bw = Files.newBufferedWriter(out);
+                JsonWriter jw = new JsonWriter(bw)) {
+
+            jw.setIndent("  ");
+            jw.beginArray();
+
+            for (Recipe<?> r : sorted) {
+                boolean hasPipeInput = false;
+                outer: for (var ingredient : r.getIngredients()) {
+                    for (var stack : ingredient.getItems()) {
+                        if (pipeItems.contains(stack.getItem())) {
+                            hasPipeInput = true;
+                            break outer;
+                        }
+                    }
+                }
+                if (!hasPipeInput)
+                    continue;
+
+                jw.beginObject();
+                jw.name("id").value(r.getId().toString());
+                jw.name("type").value(r.getType().toString());
+                jw.name("output").value(r.getResultItem(registryAccess).toString());
+                jw.name("ingredients").beginArray();
+                for (var ingredient : r.getIngredients()) {
+                    jw.beginArray();
+                    for (var stack : ingredient.getItems()) {
+                        jw.value(stack.getItem().toString());
+                    }
+                    jw.endArray();
+                }
+                jw.endArray();
+                jw.endObject();
+                count++;
+            }
+
+            jw.endArray();
+        } catch (IOException e) {
+            source.sendFailure(Component.literal("Failed to write pipe recipe dump: " + e.getMessage()));
+            return 0;
+        }
+
+        final int finalCount = count;
+        source.sendSuccess(() -> Component.literal(
+                "Dumped " + finalCount + " pipe recipes (" + pipeItems.size() + " pipe item types) to " + out.toAbsolutePath()), true);
+        return finalCount;
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/utils/commands/TFGCommands.java
+++ b/src/main/java/su/terrafirmagreg/core/utils/commands/TFGCommands.java
@@ -1,11 +1,20 @@
 package su.terrafirmagreg.core.utils.commands;
 
+import static net.minecraft.commands.Commands.literal;
+
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 
 import net.minecraft.commands.CommandSourceStack;
 
 public class TFGCommands {
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-        DustAndWindCommand.register(dispatcher);
+
+        LiteralArgumentBuilder<CommandSourceStack> debug = literal("debug")
+                .requires(c -> c.hasPermission(2));
+        DebugRecipeDump.register(debug);
+        dispatcher.register(literal("tfg").then(debug));
+
+        //DustAndWindCommand.register(dispatcher);
     }
 }


### PR DESCRIPTION
## What is the new behavior?
Ingame command to write recipes to disk.

`dump_recipes` writes all recipe IDs in a big json
`dump_recipes_details` writes recipes with inputs and outputs
`dump_pipe_recipes` writes all recipes that use a pipe as input (mostly here as an example to adapt in the code if you need anything else specific)

It sorts the recipes alphabetically by ID so it's easy to diff against if we do a refactor or update.

It's gated at access level 2 which is anyone who's op. It doesn't affect the world in any way though so it's more to hide the debug command.