### PR TITLE
Feature/gt converter fe pull

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
@@ -12,9 +12,10 @@ import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
 import com.gregtechceu.gtceu.common.machine.trait.ConverterTrait;
 
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.registries.ForgeRegistries;
 
 @Mixin(ConverterTrait.class)
 public abstract class ConverterTraitMixin extends NotifiableEnergyContainer {
@@ -24,7 +25,7 @@ public abstract class ConverterTraitMixin extends NotifiableEnergyContainer {
     }
 
     @Inject(method = "serverTick", at = @At(value = "INVOKE", target = "Lcom/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer;serverTick()V"), remap = false)
-    private void tryFeExtract(CallbackInfo ci) {
+    private void tfg$tryFeExtract(CallbackInfo ci) {
         var frontFacing = machine.getFrontFacing();
         var thisEnergyContainer = GTCapabilityHelper.getForgeEnergy(machine.getLevel(),
                 machine.getPos(), null);
@@ -32,10 +33,10 @@ public abstract class ConverterTraitMixin extends NotifiableEnergyContainer {
             if (d == frontFacing)
                 continue;
             BlockState state = machine.getLevel().getBlockState(machine.getPos().relative(d));
-            ResourceLocation id = ForgeRegistries.BLOCKS.getKey(state.getBlock());
+            Block PORTABLE_ENERGY_INTERFACE = BuiltInRegistries.BLOCK.get(ResourceLocation.tryBuild("createaddition", "portable_energy_interface"));
             var targetEnergyContainer = GTCapabilityHelper.getForgeEnergy(machine.getLevel(),
                     machine.getPos().relative(d), null);
-            if (targetEnergyContainer != null && targetEnergyContainer.canExtract() && id.getPath().contains("portable_energy_interface")) {
+            if (targetEnergyContainer != null && targetEnergyContainer.canExtract() && state.is(PORTABLE_ENERGY_INTERFACE)) {
                 int energyExtracted = targetEnergyContainer.extractEnergy(
                         thisEnergyContainer.receiveEnergy(
                                 FeCompat.toFe(

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
@@ -35,7 +35,6 @@ public abstract class ConverterTraitMixin extends NotifiableEnergyContainer {
             if (d == frontFacing)
                 continue;
             BlockState state = machine.getLevel().getBlockState(machine.getPos().relative(d));
-            Block PORTABLE_ENERGY_INTERFACE = BuiltInRegistries.BLOCK.get(ResourceLocation.tryBuild("createaddition", "portable_energy_interface"));
             var targetEnergyContainer = GTCapabilityHelper.getForgeEnergy(machine.getLevel(),
                     machine.getPos().relative(d), null);
             if (targetEnergyContainer != null && targetEnergyContainer.canExtract() && state.is(PORTABLE_ENERGY_INTERFACE)) {

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
@@ -19,6 +19,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 @Mixin(ConverterTrait.class)
 public abstract class ConverterTraitMixin extends NotifiableEnergyContainer {
+    @Unique
+    private static final Block PORTABLE_ENERGY_INTERFACE = BuiltInRegistries.BLOCK.get(ResourceLocation.fromNamespaceAndPath("createaddition", "portable_energy_interface"));
 
     public ConverterTraitMixin(MetaMachine machine, long maxCapacity, long maxInputVoltage, long maxInputAmperage, long maxOutputVoltage, long maxOutputAmperage) {
         super(machine, maxCapacity, maxInputVoltage, maxInputAmperage, maxOutputVoltage, maxOutputAmperage);

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/ConverterTraitMixin.java
@@ -1,0 +1,49 @@
+package su.terrafirmagreg.core.mixins.common.gtceu;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
+import com.gregtechceu.gtceu.api.capability.compat.FeCompat;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
+import com.gregtechceu.gtceu.common.machine.trait.ConverterTrait;
+
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.registries.ForgeRegistries;
+
+@Mixin(ConverterTrait.class)
+public abstract class ConverterTraitMixin extends NotifiableEnergyContainer {
+
+    public ConverterTraitMixin(MetaMachine machine, long maxCapacity, long maxInputVoltage, long maxInputAmperage, long maxOutputVoltage, long maxOutputAmperage) {
+        super(machine, maxCapacity, maxInputVoltage, maxInputAmperage, maxOutputVoltage, maxOutputAmperage);
+    }
+
+    @Inject(method = "serverTick", at = @At(value = "INVOKE", target = "Lcom/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer;serverTick()V"), remap = false)
+    private void tryFeExtract(CallbackInfo ci) {
+        var frontFacing = machine.getFrontFacing();
+        var thisEnergyContainer = GTCapabilityHelper.getForgeEnergy(machine.getLevel(),
+                machine.getPos(), null);
+        for (Direction d : Direction.values()) {
+            if (d == frontFacing)
+                continue;
+            BlockState state = machine.getLevel().getBlockState(machine.getPos().relative(d));
+            ResourceLocation id = ForgeRegistries.BLOCKS.getKey(state.getBlock());
+            var targetEnergyContainer = GTCapabilityHelper.getForgeEnergy(machine.getLevel(),
+                    machine.getPos().relative(d), null);
+            if (targetEnergyContainer != null && targetEnergyContainer.canExtract() && id.getPath().contains("portable_energy_interface")) {
+                int energyExtracted = targetEnergyContainer.extractEnergy(
+                        thisEnergyContainer.receiveEnergy(
+                                FeCompat.toFe(
+                                        getEnergyCapacity() - getEnergyStored(), FeCompat.ratio(false)),
+                                true),
+                        false);
+                thisEnergyContainer.receiveEnergy(energyExtracted, false);
+            }
+        }
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -78,6 +78,7 @@
         "common.greate.TieredCrushingRecipeMixin",
         "common.greate.TieredMillingRecipeMixin",
         "common.gtceu.CleanroomConditionMixin",
+        "common.gtceu.ConverterTraitMixin",
         "common.gtceu.DimensionConditionMixin",
         "common.gtceu.EntityDamageUtilMixin",
         "common.gtceu.GrowingPlantRenderMixin",


### PR DESCRIPTION
## What is the new behavior?
Adds the ability for all Converters to pull FE from the Portable Energy Interface

## Implementation Details
This limits which FE containers Converters can pull from based on the Block ID, which is somewhat hacky but workable without changing Create Addition's side.

## Outcome
Resolves the issue below
[#2460](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2460)

## Potential Compatibility Issues
If the Block ID of the Portable Energy Interface is changed, this breaks

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
DrEthan
