### PR TITLE
Remove unnecessary EventBusSubscriber annotation from ClientProxy

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ClientProxy.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ClientProxy.java
@@ -1,7 +1,6 @@
 package su.terrafirmagreg.core.client;
 
 import static earth.terrarium.adastra.client.forge.AdAstraClientForge.ITEM_RENDERERS;
-import static su.terrafirmagreg.core.common.data.TFGEntities.*;
 
 import java.util.function.BiConsumer;
 
@@ -19,7 +18,6 @@ import net.minecraft.world.item.Item;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 import earth.terrarium.adastra.client.models.entities.vehicles.RocketModel;

--- a/src/main/java/su/terrafirmagreg/core/client/ClientProxy.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ClientProxy.java
@@ -34,7 +34,6 @@ import su.terrafirmagreg.core.common.data.entities.sniffer.*;
 import su.terrafirmagreg.core.common.data.particles.*;
 import su.terrafirmagreg.core.common.data.tfgt.machine.render.BouleRender;
 
-@Mod.EventBusSubscriber(modid = TFGCore.MOD_ID)
 public class ClientProxy extends CommonProxy {
     public ClientProxy() {
         super();


### PR DESCRIPTION
## What is the new behavior?
This PR removes the `@Mod.EventBusSubscriber` annotation from `ClientProxy`.

`ClientProxy` is already instantiated only on the client through `DistExecutor` in `TFGCore`, and it is already registered to the mod event bus through the proxy setup in `CommonProxy`. Because of that, the automatic event bus subscriber annotation is redundant.

Leaving the annotation in place causes Forge to try to automatically load `ClientProxy` during mod subscriber discovery on a dedicated server. Since `ClientProxy` references client-only classes such as particle provider registration code, this can lead to dedicated server startup failure with `NoClassDefFoundError` for client-side classes.

This PR ensures that `ClientProxy` is only loaded through the intended client-only proxy path and not through automatic subscriber scanning.

## Outcome
- Fixes a server-side classloading issue caused by client-only references inside `ClientProxy`.

Discord nickname: sqcode