### PR TITLE
Potentially fix rockets killing 2nd passenger on servers

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 
 import earth.terrarium.adastra.common.entities.vehicles.Rocket;
@@ -95,6 +96,16 @@ public abstract class RocketMixin extends Entity {
                 TFGEntities.TIER_2_DOUBLE_ROCKET.get(), TIER_2_DOUBLE_PROPERTIES,
                 TFGEntities.TIER_3_DOUBLE_ROCKET.get(), TIER_3_DOUBLE_PROPERTIES,
                 TFGEntities.TIER_4_DOUBLE_ROCKET.get(), TIER_4_DOUBLE_PROPERTIES);
+    }
+
+    @Redirect(method = "burnEntitiesUnderRocket", at = @At(value = "INVOKE", target = "net/minecraft/world/entity/LivingEntity.equals (Ljava/lang/Object;)Z"))
+    private boolean tfg$dontBurnPassengers(LivingEntity instance, Object o) {
+        List<Entity> passengers = tfg$self.getPassengers();
+
+        for (var entity : passengers) {
+            return instance.equals(entity);
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3317

Due to how inconsistent this bug seems to be, I can't test if this actually worked, but I didn't die in singleplayer. Instead of only checking the controlling passenger, I now check all passengers, which should solve the issue.