### PR TITLE
Fix EMI bookmark recipe tooltip when GT machine GUI is open

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/client/ldlib/ModularUIGuiContainerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/ldlib/ModularUIGuiContainerMixin.java
@@ -1,0 +1,22 @@
+package su.terrafirmagreg.core.mixins.client.ldlib;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.lowdragmc.lowdraglib.gui.modular.ModularUIGuiContainer;
+
+/**
+ * Disables LDLib's redundant EMI rendering calls in ModularUIGuiContainer.render().
+ * EMI's own Forge event hooks already handle this for any AbstractContainerScreen.
+ * The redundant calls cause double rendering and leave stale depth buffer values that occlude items in EMI tooltips.
+ */
+@Mixin(value = ModularUIGuiContainer.class)
+public abstract class ModularUIGuiContainerMixin {
+
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lcom/lowdragmc/lowdraglib/LDLib;isEmiLoaded()Z"))
+    private boolean tfg$disableRedundantEmiRendering() {
+        // For this method only, pretend EMI isn't loaded at all
+        return false;
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -218,6 +218,7 @@
         "client.ftb.ClientTeamManagerImplMixin",
         "client.ftb.QuestScreenMixin",
         "client.gtceu.ISurfaceRockRendererAccessor",
+        "client.ldlib.ModularUIGuiContainerMixin",
         "client.minecraft.CreateWorldScreenMixin",
         "client.tfc.ClimateRenderCacheMixin",
         "client.tfc.DoubleIngotPileBlockModelMixin",


### PR DESCRIPTION
Fix for https://github.com/Low-Drag-MC/LDLib-MultiLoader/issues/112

