### PR TITLE
Remove vanilla advancements

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -14,9 +14,12 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import vazkii.patchouli.client.book.ClientBookRegistry;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.capabilities.ILargeEgg;
@@ -29,6 +32,16 @@ import su.terrafirmagreg.core.common.data.events.WeakOreProspectorEventHelper;
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
 @OnlyIn(Dist.CLIENT)
 public class ForgeClientEventListener {
+
+    /**
+     * Load Patchouli's book manually on player login.
+     * Workaround for Pachouli books not loading when no Advancements are registered on the server.
+     * With no advancements, ClientAdvancements::onClientPacket doesn't fire, which gates initial load.
+     */
+    @SubscribeEvent
+    public static void onClientLogin(ClientPlayerNetworkEvent.LoggingIn event) {
+        ClientBookRegistry.INSTANCE.reload();
+    }
 
     @SubscribeEvent
     public static void onTooltip(@NotNull ItemTooltipEvent event) {

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/ServerAdvancementManagerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/ServerAdvancementManagerMixin.java
@@ -4,25 +4,27 @@ import java.util.Map;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.advancements.Advancement;
-import net.minecraft.advancements.AdvancementList;
+import com.google.gson.JsonElement;
+
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.ServerAdvancementManager;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.profiling.ProfilerFiller;
 
 @Mixin(ServerAdvancementManager.class)
 public abstract class ServerAdvancementManagerMixin {
 
     /**
-     * Препятствует добавлению достижений в игру. Но не удаляет достижения ваниллы, так как из-за этого перестает
-     * работать книга Patchouli. Стоит поискать решение. - Prevents achievements from other mods. However, it doesn't
-     * remove vanilla achievements, because otherwise Patchouli stops working. It's worth looking for a better solution
-     * to hide the vanilla advancements.
+     * Removes all advancements from loading, skipping JSON parsing entirely.
+     * Make sure to call ClientBookRegistry.INSTANCE.reload() manually,
+     * otherwise Patchouli's ClientAdvancements::onClientPacket gate prevents initial loading.
+     * @see su.terrafirmagreg.core.client.ForgeClientEventListener#onClientLogin
      */
-    @Redirect(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/advancements/AdvancementList;add(Ljava/util/Map;)V"))
-    private void tfg$apply$advancementList$add(AdvancementList list, Map<ResourceLocation, Advancement.Builder> map) {
-        map.entrySet().removeIf(entry -> !entry.getKey().getNamespace().equals("minecraft"));
-        list.add(map);
+    @Inject(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At("HEAD"), cancellable = true)
+    private void tfg$removeAdvancements(Map<ResourceLocation, JsonElement> pObject, ResourceManager pResourceManager, ProfilerFiller pProfiler, CallbackInfo ci) {
+        ci.cancel();
     }
 }


### PR DESCRIPTION
## What is the new behavior?
Removes all advancements, including vanilla.

Manually loads Patchoulli on player login, because normally it only loads when the client receives its first advancement packet from the server. Workaround for https://github.com/VazkiiMods/Patchouli/issues/845

Should save ~0.1ms servertime per tick per player