### PR TITLE
SupportCache Jade tooltip fix

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -12,10 +12,13 @@ import net.minecraft.util.Mth;
 import net.minecraft.util.StringUtil;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -28,6 +31,7 @@ import su.terrafirmagreg.core.common.data.events.AdvancedOreProspectorEventHelpe
 import su.terrafirmagreg.core.common.data.events.NormalOreProspectorEventHelper;
 import su.terrafirmagreg.core.common.data.events.OreProspectorEvent;
 import su.terrafirmagreg.core.common.data.events.WeakOreProspectorEventHelper;
+import su.terrafirmagreg.core.common.perf.SupportCache;
 
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
 @OnlyIn(Dist.CLIENT)
@@ -41,6 +45,19 @@ public class ForgeClientEventListener {
     @SubscribeEvent
     public static void onClientLogin(ClientPlayerNetworkEvent.LoggingIn event) {
         ClientBookRegistry.INSTANCE.reload();
+    }
+
+    /**
+     * Evict client-side SupportCache chunk to prevent stale cache info.
+     * Clients don't get placement/removal updates for chunks that aren't in range, so we can't trust the cache
+     * for those chunks.
+     */
+    @SubscribeEvent
+    public static void onChunkUnload(ChunkEvent.Unload event) {
+        if (event.getLevel() instanceof Level level) {
+            ChunkPos pos = event.getChunk().getPos();
+            SupportCache.forLevel(level).evictChunk(pos.x, pos.z);
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
@@ -1,8 +1,8 @@
 package su.terrafirmagreg.core.common;
 
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -52,8 +52,8 @@ public final class ForgeCommonEventListener {
 
     @SubscribeEvent
     public static void onLevelUnload(LevelEvent.Unload event) {
-        if (!(event.getLevel() instanceof ServerLevel level))
-            return;
-        SupportCache.clearLevel(level.dimension());
+        if (event.getLevel() instanceof Level level) {
+            SupportCache.clearLevel(level);
+        }
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/common/perf/SupportCache.java
+++ b/src/main/java/su/terrafirmagreg/core/common/perf/SupportCache.java
@@ -10,12 +10,12 @@ import java.util.Set;
 import net.dries007.tfc.util.Support;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkStatus;
+import net.minecraft.world.level.chunk.EmptyLevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainer;
 
@@ -24,18 +24,21 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 
 /**
  * Per-level cache of support block AABBs.
- * Replaces Support.isSupported()'s brute-force 14k block scan with a few AABB check.
+ * Replaces Support.isSupported()'s brute-force 14k block scan with a few AABB checks.
  */
 public class SupportCache {
 
-    private static final Map<ResourceKey<Level>, SupportCache> CACHES = new HashMap<>();
+    private static final Map<ResourceKey<Level>, SupportCache> SERVER_CACHES = new HashMap<>();
+    private static final Map<ResourceKey<Level>, SupportCache> CLIENT_CACHES = new HashMap<>();
 
-    public static SupportCache forLevel(ServerLevel level) {
-        return CACHES.computeIfAbsent(level.dimension(), k -> new SupportCache());
+    public static SupportCache forLevel(Level level) {
+        var caches = level.isClientSide() ? CLIENT_CACHES : SERVER_CACHES;
+        return caches.computeIfAbsent(level.dimension(), k -> new SupportCache());
     }
 
-    public static void clearLevel(ResourceKey<Level> dimension) {
-        CACHES.remove(dimension);
+    public static void clearLevel(Level level) {
+        var caches = level.isClientSide() ? CLIENT_CACHES : SERVER_CACHES;
+        caches.remove(level.dimension());
     }
 
     // Maps chunk long pos -> list of (pos, aabb) entries for supports in that chunk
@@ -49,7 +52,7 @@ public class SupportCache {
     /**
      * Check if a BlockPos is supported.
      */
-    public boolean isSupported(ServerLevel level, BlockPos pos) {
+    public boolean isSupported(Level level, BlockPos pos) {
         int horizontal = Support.getSupportCheckRange().horizontal();
 
         int minCX = (pos.getX() - horizontal) >> 4;
@@ -92,13 +95,15 @@ public class SupportCache {
      * Find all support blocks in a chunk.
      * Does a very low-level scan of the raw PalettedContainer data to make things fast.
      */
-    private void scanChunk(ServerLevel level, int cx, int cz) {
+    private void scanChunk(Level level, int cx, int cz) {
         long key = ChunkPos.asLong(cx, cz);
-        scannedChunks.add(key);
 
         ChunkAccess chunk = level.getChunkSource().getChunk(cx, cz, ChunkStatus.FULL, true);
-        if (chunk == null)
+        if (chunk == null || chunk instanceof EmptyLevelChunk)
+            // Clientside returns EmptyLevelChunk for unloaded chunks, we don't want to scan those or mark them as scanned
             return;
+
+        scannedChunks.add(key);
 
         List<SupportEntry> entries = new ArrayList<>();
         LevelChunkSection[] sections = chunk.getSections();
@@ -150,7 +155,7 @@ public class SupportCache {
      * Build a set of BlockPos between the given positions, then remove all BlockPos that are supported from this set.
      * @return a Set<BlockPos> of unsupported blocks.
      */
-    public Set<BlockPos> findUnsupportedPositions(ServerLevel level, BlockPos from, BlockPos to) {
+    public Set<BlockPos> findUnsupportedPositions(Level level, BlockPos from, BlockPos to) {
         int minX = Math.min(from.getX(), to.getX());
         int maxX = Math.max(from.getX(), to.getX());
         int minY = Math.min(from.getY(), to.getY());
@@ -200,6 +205,16 @@ public class SupportCache {
         }
 
         return unsupported;
+    }
+
+    /**
+     * Used only ClientSide to prevent stale cache info. Serverside will always be in sync because server is the
+     * source of truth.
+     */
+    public void evictChunk(int cx, int cz) {
+        long key = ChunkPos.asLong(cx, cz);
+        scannedChunks.remove(key);
+        chunkSupports.remove(key);
     }
 
     public void addSupport(BlockPos pos, Support support) {

--- a/src/main/java/su/terrafirmagreg/core/common/perf/SupportCache.java
+++ b/src/main/java/su/terrafirmagreg/core/common/perf/SupportCache.java
@@ -1,9 +1,7 @@
 package su.terrafirmagreg.core.common.perf;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,8 +39,8 @@ public class SupportCache {
         caches.remove(level.dimension());
     }
 
-    // Maps chunk long pos -> list of (pos, aabb) entries for supports in that chunk
-    private final Map<Long, List<SupportEntry>> chunkSupports = new HashMap<>();
+    // Maps chunk long pos -> map of support block positions to their AABB entries
+    private final Map<Long, Map<BlockPos, SupportEntry>> chunkSupports = new HashMap<>();
     // Tracks which chunks have been scanned, even if they contained no supports
     private final Set<Long> scannedChunks = new HashSet<>();
 
@@ -70,17 +68,19 @@ public class SupportCache {
                     scanChunk(level, cx, cz);
                 }
 
-                List<SupportEntry> entries = chunkSupports.get(key);
+                Map<BlockPos, SupportEntry> entries = chunkSupports.get(key);
                 if (entries == null)
                     continue;
 
-                var it = entries.iterator();
+                var it = entries.entrySet().iterator();
                 while (it.hasNext()) {
-                    SupportEntry entry = it.next();
-                    if (entry.contains(pos)) {
-                        // Sanity check
-                        if (Support.get(level.getBlockState(entry.pos())) == null) {
+                    var e = it.next();
+                    if (e.getValue().contains(pos)) {
+                        // Sanity check and clientside eviction
+                        if (Support.get(level.getBlockState(e.getKey())) == null) {
                             it.remove();
+                            if (entries.isEmpty())
+                                chunkSupports.remove(key);
                         } else {
                             return true;
                         }
@@ -105,7 +105,7 @@ public class SupportCache {
 
         scannedChunks.add(key);
 
-        List<SupportEntry> entries = new ArrayList<>();
+        Map<BlockPos, SupportEntry> entries = new HashMap<>();
         LevelChunkSection[] sections = chunk.getSections();
 
         for (int sectionIdx = 0; sectionIdx < sections.length; sectionIdx++) {
@@ -140,7 +140,7 @@ public class SupportCache {
                     BlockPos supportPos = new BlockPos((cx << 4) + x, baseY + y, (cz << 4) + z);
                     Support support = Support.get(palette.valueFor(paletteIdx));
                     assert support != null;
-                    entries.add(SupportEntry.of(supportPos, support));
+                    entries.put(supportPos, SupportEntry.of(supportPos, support));
                 }
                 slot[0]++;
             });
@@ -180,17 +180,27 @@ public class SupportCache {
                 if (!scannedChunks.contains(key)) {
                     scanChunk(level, cx, cz);
                 }
-                List<SupportEntry> entries = chunkSupports.get(key);
+                Map<BlockPos, SupportEntry> entries = chunkSupports.get(key);
                 if (entries == null)
                     continue;
 
-                for (SupportEntry entry : entries) {
+                var it = entries.entrySet().iterator();
+                while (it.hasNext()) {
+                    var e = it.next();
+                    SupportEntry entry = e.getValue();
                     if (entry.maxX() < minX || entry.minX() > maxX)
                         continue;
                     if (entry.maxY() < minY || entry.minY() > maxY)
                         continue;
                     if (entry.maxZ() < minZ || entry.minZ() > maxZ)
                         continue;
+                    // Sanity check and clientside eviction
+                    if (Support.get(level.getBlockState(e.getKey())) == null) {
+                        it.remove();
+                        if (entries.isEmpty())
+                            chunkSupports.remove(key);
+                        continue;
+                    }
                     int ex1 = Math.max(entry.minX(), minX);
                     int ex2 = Math.min(entry.maxX(), maxX);
                     int ey1 = Math.max(entry.minY(), minY);
@@ -219,29 +229,24 @@ public class SupportCache {
 
     public void addSupport(BlockPos pos, Support support) {
         long key = ChunkPos.asLong(pos.getX() >> 4, pos.getZ() >> 4);
-        List<SupportEntry> entries = chunkSupports.computeIfAbsent(key, k -> new ArrayList<>());
-        for (SupportEntry e : entries) {
-            if (e.pos().equals(pos))
-                return;
-        }
-        entries.add(SupportEntry.of(pos, support));
+        chunkSupports.computeIfAbsent(key, k -> new HashMap<>())
+                .put(pos, SupportEntry.of(pos, support));
     }
 
     public void removeSupport(BlockPos pos) {
         long key = ChunkPos.asLong(pos.getX() >> 4, pos.getZ() >> 4);
-        List<SupportEntry> entries = chunkSupports.get(key);
+        Map<BlockPos, SupportEntry> entries = chunkSupports.get(key);
         if (entries != null) {
-            entries.removeIf(e -> e.pos().equals(pos));
+            entries.remove(pos);
             if (entries.isEmpty())
                 chunkSupports.remove(key);
         }
     }
 
-    public record SupportEntry(BlockPos pos, int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
+    public record SupportEntry(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
 
         public static SupportEntry of(BlockPos pos, Support support) {
             return new SupportEntry(
-                    pos,
                     pos.getX() - support.getSupportHorizontal(),
                     pos.getY() - support.getSupportDown(),
                     pos.getZ() - support.getSupportHorizontal(),

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/HorizontalSupportBlockMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/HorizontalSupportBlockMixin.java
@@ -13,7 +13,6 @@ import net.dries007.tfc.common.blocks.wood.HorizontalSupportBlock;
 import net.dries007.tfc.common.blocks.wood.VerticalSupportBlock;
 import net.dries007.tfc.util.Support;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -33,12 +32,10 @@ public abstract class HorizontalSupportBlockMixin extends VerticalSupportBlock {
      */
     @Inject(method = "setPlacedBy", at = @At("HEAD"))
     private void tfg$cachePlacedPos(Level level, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack, CallbackInfo ci) {
-        if (!(level instanceof ServerLevel serverLevel))
-            return;
         Support support = Support.get(state);
         if (support == null)
             return;
-        SupportCache.forLevel(serverLevel).addSupport(pos.immutable(), support);
+        SupportCache.forLevel(level).addSupport(pos.immutable(), support);
     }
 
     /**
@@ -47,10 +44,10 @@ public abstract class HorizontalSupportBlockMixin extends VerticalSupportBlock {
     @WrapOperation(method = "setPlacedBy", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z"))
     private boolean tfg$cacheSetBlock(Level level, BlockPos pos, BlockState state, int flags, Operation<Boolean> original) {
         boolean result = original.call(level, pos, state, flags);
-        if (result && level instanceof ServerLevel serverLevel) {
+        if (result) {
             Support support = Support.get(state);
             if (support != null) {
-                SupportCache.forLevel(serverLevel).addSupport(pos.immutable(), support);
+                SupportCache.forLevel(level).addSupport(pos.immutable(), support);
             }
         }
         return result;
@@ -59,8 +56,8 @@ public abstract class HorizontalSupportBlockMixin extends VerticalSupportBlock {
     @SuppressWarnings({ "NullableProblems", "deprecation" })
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (level instanceof ServerLevel serverLevel && state.getBlock() != newState.getBlock()) {
-            SupportCache.forLevel(serverLevel).removeSupport(pos);
+        if (state.getBlock() != newState.getBlock()) {
+            SupportCache.forLevel(level).removeSupport(pos);
         }
         super.onRemove(state, level, pos, newState, isMoving);
     }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/HorizontalSupportBlockMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/HorizontalSupportBlockMixin.java
@@ -53,6 +53,11 @@ public abstract class HorizontalSupportBlockMixin extends VerticalSupportBlock {
         return result;
     }
 
+    /**
+     * Unfortunately this is only called ServerSide, so the clientside cache may contain stale supports.
+     * In practice this is no problem because we doublecheck all found supports and remove them if they're stale,
+     * so clientside the cache is just a little lazier about removal.
+     */
     @SuppressWarnings({ "NullableProblems", "deprecation" })
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/SupportMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/SupportMixin.java
@@ -10,8 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.dries007.tfc.util.Support;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 
 import su.terrafirmagreg.core.common.perf.SupportCache;
 
@@ -19,12 +19,12 @@ import su.terrafirmagreg.core.common.perf.SupportCache;
 public class SupportMixin {
 
     /**
-     * Check our support cache to see if this position is supported by a HorizontalSupportBlock
+     * Check our support cache to see if this position is supported by a HorizontalSupportBlock.
      */
     @Inject(method = "isSupported", at = @At("HEAD"), cancellable = true)
     private static void tfg$useSupportCache(BlockGetter world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        if (world instanceof ServerLevel serverLevel) {
-            cir.setReturnValue(SupportCache.forLevel(serverLevel).isSupported(serverLevel, pos));
+        if (world instanceof Level level) {
+            cir.setReturnValue(SupportCache.forLevel(level).isSupported(level, pos));
         }
     }
 
@@ -34,10 +34,9 @@ public class SupportMixin {
      */
     @Overwrite
     public static Set<BlockPos> findUnsupportedPositions(BlockGetter world, BlockPos from, BlockPos to) {
-        if (world instanceof ServerLevel serverLevel) {
-            return SupportCache.forLevel(serverLevel).findUnsupportedPositions(serverLevel, from, to);
+        if (world instanceof Level level) {
+            return SupportCache.forLevel(level).findUnsupportedPositions(level, from, to);
         }
-        // Clientside: Return empty
         return Set.of();
     }
 }


### PR DESCRIPTION
## What is the new behavior?
Fixes the issue where jade always says "Won't collapse", even if it will collapse.

## Bug cause
Initially I thought that `findUnsupportedPositions` was never called clientside because it only seems to be used for actual collapses that are in progress. So I returned an empty set clientside. But the tfc-support-indicator tooltip also uses it for the "won't cause collapse" line, so that line always thought there were no unsupported blocks nearby.

## Implementation Details
Added a ClientSide version of the SupportCache to check against. It gets populated and synced a little bit differently, because clientside we don't have a guarantee that the world doesn't change when a chunk is unloaded. We also don't get onRemove calls. So to keep it in sync we have to evict unloaded chunks from the cache and also doublecheck if a support still exists when we query it.

## Outcome
Jade and the server should now agree.