### PR TITLE
Fix livestock breeding

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/BreedBehaviorMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/BreedBehaviorMixin.java
@@ -1,0 +1,27 @@
+package su.terrafirmagreg.core.mixins.common.tfc;
+
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import net.dries007.tfc.common.entities.ai.livestock.BreedBehavior;
+
+@Mixin(value = BreedBehavior.class, remap = false)
+public class BreedBehaviorMixin {
+
+    /**
+     * Allow the spawn check to pass up to 10 ticks early to account for brain tick throttling.
+     * Normally the spawning happens on the last valid tick of the BreedBehavior before timeout,
+     * but with the throttle we might miss this moment.
+     */
+    // spotless:off
+    @ModifyExpressionValue(
+            method = "tick(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/animal/Animal;J)V",
+            at = @At(value = "FIELD", target = "Lnet/dries007/tfc/common/entities/ai/livestock/BreedBehavior;spawnChildAtTime:J", opcode = Opcodes.GETFIELD))
+    // spotless:on
+    private long tfg$allowEarlierSpawn(long spawnChildAtTime) {
+        return spawnChildAtTime - 10;
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -151,6 +151,7 @@
         "common.species.LimpetMixin",
         "common.species.SpringlingMixin",
         "common.species.TrooperMixin",
+        "common.tfc.BreedBehaviorMixin",
         "common.tfc.BlastFurnaceBlockEntityMixin",
         "common.tfc.BloomeryBlockEntityMixin",
         "common.tfc.CaveSpikesFeatureMixin",


### PR DESCRIPTION
## What
Fixes [#3382](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3382)
Because pigs only think every third tick, they sometimes miss the only moment for breeding. This PR gives them a little more time for making babies.

## Details
The actual fertilization happens on the very last tick of the BreedingBehavior, but with the brain tick throttling we often miss that tick. This mixin increases the window in which the fertilization can happen.