### PR TITLE
Fix Artisan EMI layout

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/compat/emi/ArtisanTableEmiRecipe.java
+++ b/src/main/java/su/terrafirmagreg/core/compat/emi/ArtisanTableEmiRecipe.java
@@ -151,7 +151,7 @@ public class ArtisanTableEmiRecipe implements EmiRecipe {
         }
 
         if (!this.getOutputs().isEmpty()) {
-            holder.addSlot(this.getOutputs().get(0), xPos - xDiff + 11, yPos + 5).recipeContext(this);
+            holder.addSlot(this.getOutputs().get(0), xPos - xDiff + 11, 10 + yDiff * 2 + 5).recipeContext(this);
         }
 
         displayPattern(holder);


### PR DESCRIPTION
## What is the new behavior?
Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3374

## Implementation Details
xPos and yPos are changed during placing of the input slots. Because the input slots can have 3 or 4 inputs, we can't rely on its value to be consistent after the loop. The output slot is now set independent from the final yPos value.