### PR TITLE
Load Patchouli on first open instead of on login

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -16,13 +16,10 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-
-import vazkii.patchouli.client.book.ClientBookRegistry;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.capabilities.ILargeEgg;
@@ -36,16 +33,6 @@ import su.terrafirmagreg.core.common.perf.SupportCache;
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
 @OnlyIn(Dist.CLIENT)
 public class ForgeClientEventListener {
-
-    /**
-     * Load Patchouli's book manually on player login.
-     * Workaround for Pachouli books not loading when no Advancements are registered on the server.
-     * With no advancements, ClientAdvancements::onClientPacket doesn't fire, which gates initial load.
-     */
-    @SubscribeEvent
-    public static void onClientLogin(ClientPlayerNetworkEvent.LoggingIn event) {
-        ClientBookRegistry.INSTANCE.reload();
-    }
 
     /**
      * Evict client-side SupportCache chunk to prevent stale cache info.

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/patchouli/ClientBookRegistryMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/patchouli/ClientBookRegistryMixin.java
@@ -1,0 +1,29 @@
+package su.terrafirmagreg.core.mixins.client.patchouli;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.resources.ResourceLocation;
+
+import vazkii.patchouli.client.book.ClientBookRegistry;
+
+@Mixin(value = ClientBookRegistry.class, remap = false)
+public abstract class ClientBookRegistryMixin {
+
+    @Unique
+    private boolean tfg$hasReloaded = false;
+
+    /**
+     * Ensures Patchouli books are loaded on first book open.
+     */
+    @Inject(method = "displayBookGui", at = @At("HEAD"))
+    private void tfg$ensureBooksLoaded(ResourceLocation bookStr, ResourceLocation entryId, int page, CallbackInfo ci) {
+        if (!tfg$hasReloaded) {
+            ((ClientBookRegistry) (Object) this).reload();
+            tfg$hasReloaded = true;
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/ServerAdvancementManagerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/ServerAdvancementManagerMixin.java
@@ -19,9 +19,9 @@ public abstract class ServerAdvancementManagerMixin {
 
     /**
      * Removes all advancements from loading, skipping JSON parsing entirely.
-     * Make sure to call ClientBookRegistry.INSTANCE.reload() manually,
-     * otherwise Patchouli's ClientAdvancements::onClientPacket gate prevents initial loading.
-     * @see su.terrafirmagreg.core.client.ForgeClientEventListener#onClientLogin
+     * Without advancements, Patchouli's ClientAdvancements::onClientPacket never fires,
+     * so {@link su.terrafirmagreg.core.mixins.client.patchouli.ClientBookRegistryMixin}
+     * ensures books are loaded on first open instead.
      */
     @Inject(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At("HEAD"), cancellable = true)
     private void tfg$removeAdvancements(Map<ResourceLocation, JsonElement> pObject, ResourceManager pResourceManager, ProfilerFiller pProfiler, CallbackInfo ci) {

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -218,6 +218,7 @@
         "client.firmalife.FLBeehiveBlockMixin",
         "client.ftb.ClientTeamManagerImplMixin",
         "client.ftb.QuestScreenMixin",
+        "client.patchouli.ClientBookRegistryMixin",
         "client.gtceu.ISurfaceRockRendererAccessor",
         "client.ldlib.ModularUIGuiContainerMixin",
         "client.minecraft.CreateWorldScreenMixin",


### PR DESCRIPTION
## What is the new behavior?
Fixes this:
<img width="1125" height="736" alt="image" src="https://github.com/user-attachments/assets/411f4d68-78d7-4984-a9b0-721cba62b481" />


## Bug details
I forced loading of the book on player login. This is apparently too early, as the recipes aren't registered yet.

## Fix details
I now force loading the first time the player opens the book, if it hasn't been loaded yet. Presumably the player is already ingame and moving around at that point so the recipes should be loaded.