### PR TITLE
tfc:drinkable Tooltip

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -14,11 +14,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.util.StringUtil;
-import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
@@ -41,6 +41,7 @@ import su.terrafirmagreg.core.common.perf.SupportCache;
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
 @OnlyIn(Dist.CLIENT)
 public class ForgeClientEventListener {
+    private static final TagKey<Fluid> TFC_DRINKABLE_TAG = TagKey.create(Registries.FLUID, ResourceLocation.fromNamespaceAndPath("tfc", "drinkables"));
 
     /**
      * Evict client-side SupportCache chunk to prevent stale cache info.
@@ -127,13 +128,12 @@ public class ForgeClientEventListener {
                 foodProperties.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(effect.getFirst())));
             }
 
-            var alcoholTag = TagKey.create(Registries.FLUID, ResourceLocation.fromNamespaceAndPath("tfc", "drinkables"));
             stack.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM).ifPresent(capability -> {
                 FluidStack fluidStack = capability.getFluidInTank(0);
-                if (fluidStack.getFluid().is(alcoholTag) && !ForgeRegistries.FLUIDS.getKey(fluidStack.getFluid()).getNamespace().equals("tfcagedalcohol")) {
+                if (fluidStack.getFluid().is(TFC_DRINKABLE_TAG) && !ForgeRegistries.FLUIDS.getKey(fluidStack.getFluid()).getNamespace().equals("tfcagedalcohol")) {
                     Drinkable drink = Drinkable.get(fluidStack.getFluid());
                     if (drink != null) {
-                        drink.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(effect.type(), effect.duration(), effect.amplifier())));
+                        drink.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(new MobEffectInstance(effect.type(), effect.duration(), effect.amplifier()))));
                     }
                 }
             });
@@ -141,11 +141,6 @@ public class ForgeClientEventListener {
     }
 
     // These are taken from TFC Aged Alcohol
-
-    private static Component getTooltip(MobEffect effect, int duration, int amplifier) {
-        MobEffectInstance effectInstance = new MobEffectInstance(effect, duration, amplifier);
-        return Component.literal(effect.getDisplayName().getString() + displayedPotency(amplifier) + "(" + formatDuration(effectInstance) + ")").withStyle(effect.getCategory().getTooltipFormatting());
-    }
 
     private static Component getTooltip(MobEffectInstance effectInstance) {
         return Component.literal(effectInstance.getEffect().getDisplayName().getString()

--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -6,20 +6,28 @@ import javax.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
 
+import net.dries007.tfc.util.Drinkable;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.util.StringUtil;
+import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.capabilities.ILargeEgg;
@@ -118,10 +126,26 @@ public class ForgeClientEventListener {
             if (foodProperties != null) {
                 foodProperties.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(effect.getFirst())));
             }
+
+            var alcoholTag = TagKey.create(Registries.FLUID, ResourceLocation.fromNamespaceAndPath("tfc", "drinkables"));
+            stack.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM).ifPresent(capability -> {
+                FluidStack fluidStack = capability.getFluidInTank(0);
+                if (fluidStack.getFluid().is(alcoholTag) && !ForgeRegistries.FLUIDS.getKey(fluidStack.getFluid()).getNamespace().equals("tfcagedalcohol")) {
+                    Drinkable drink = Drinkable.get(fluidStack.getFluid());
+                    if (drink != null) {
+                        drink.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(effect.type(), effect.duration(), effect.amplifier())));
+                    }
+                }
+            });
         }
     }
 
     // These are taken from TFC Aged Alcohol
+
+    private static Component getTooltip(MobEffect effect, int duration, int amplifier) {
+        MobEffectInstance effectInstance = new MobEffectInstance(effect, duration, amplifier);
+        return Component.literal(effect.getDisplayName().getString() + displayedPotency(amplifier) + "(" + formatDuration(effectInstance) + ")").withStyle(effect.getCategory().getTooltipFormatting());
+    }
 
     private static Component getTooltip(MobEffectInstance effectInstance) {
         return Component.literal(effectInstance.getEffect().getDisplayName().getString()


### PR DESCRIPTION
### What is the new behavior?
Drinkables that have effects and have `#tfc:drinkables` tag now have effect tooltip. Excludes liquids with `tfcagedalcohols` namespace.

### Implementation Details
- ForgeClientListened.java

### Additional Information
- I used `.is()` which, apparently, is deprecated (`.builtInRegistryHolder()` also, but did not use it here).
- @gustovafing
- If the PR will be merged I will also need to fix some tags through KubeJS.

### Potential Compatibility Issues
- Technically my first "actual" Java code. I would appreciate info on what could be improved.