### PR TITLE
Moved imy Item Tooltip Code to Prevent Crashes on Startup

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -1,44 +1,26 @@
 package su.terrafirmagreg.core.client;
 
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import org.jetbrains.annotations.NotNull;
 
 import net.dries007.tfc.client.TFCColors;
 import net.dries007.tfc.common.blocks.soil.ConnectedGrassBlock;
-import net.dries007.tfc.util.Drinkable;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.item.ItemColor;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
-import net.minecraft.util.Mth;
-import net.minecraft.util.StringUtil;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
-import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.TFGBlocks_Earth;
 import su.terrafirmagreg.core.common.data.TFGPlant;
-import su.terrafirmagreg.core.common.data.capabilities.ILargeEgg;
-import su.terrafirmagreg.core.common.data.capabilities.LargeEggCapability;
 import su.terrafirmagreg.core.common.data.events.AdvancedOreProspectorEventHelper;
 import su.terrafirmagreg.core.common.data.events.NormalOreProspectorEventHelper;
 import su.terrafirmagreg.core.common.data.events.OreProspectorEvent;
@@ -48,7 +30,6 @@ import su.terrafirmagreg.core.common.perf.SupportCache;
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
 @OnlyIn(Dist.CLIENT)
 public class ForgeClientEventListener {
-    private static final TagKey<Fluid> TFC_DRINKABLE_TAG = TagKey.create(Registries.FLUID, ResourceLocation.fromNamespaceAndPath("tfc", "drinkables"));
 
     /**
      * Evict client-side SupportCache chunk to prevent stale cache info.
@@ -118,35 +99,6 @@ public class ForgeClientEventListener {
         }
     }
 
-    @SuppressWarnings({ "deprecation", "ConstantConditions" })
-    @SubscribeEvent
-    public static void onItemTooltip(ItemTooltipEvent event) {
-        final ItemStack stack = event.getItemStack();
-        final List<Component> text = event.getToolTip();
-        if (!stack.isEmpty()) {
-            final @Nullable ILargeEgg egg = LargeEggCapability.get(stack);
-            if (egg != null) {
-                egg.addTooltipInfo(text);
-                return;
-            }
-
-            var foodProperties = stack.getFoodProperties(event.getEntity());
-            if (foodProperties != null) {
-                foodProperties.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(effect.getFirst())));
-            }
-
-            stack.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM).ifPresent(capability -> {
-                FluidStack fluidStack = capability.getFluidInTank(0);
-                if (fluidStack.getFluid().is(TFC_DRINKABLE_TAG) && !ForgeRegistries.FLUIDS.getKey(fluidStack.getFluid()).getNamespace().equals("tfcagedalcohol")) {
-                    Drinkable drink = Drinkable.get(fluidStack.getFluid());
-                    if (drink != null) {
-                        drink.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(new MobEffectInstance(effect.type(), effect.duration(), effect.amplifier()))));
-                    }
-                }
-            });
-        }
-    }
-
     public static void registerColorHandlerBlocks(RegisterColorHandlersEvent.Block event) {
         final BlockColor grassColor = (state, level, pos, tintIndex) -> TFCColors.getGrassColor(pos, tintIndex);
         final BlockColor tallGrassColor = (state, level, pos, tintIndex) -> TFCColors.getTallGrassColor(pos, tintIndex);
@@ -175,24 +127,4 @@ public class ForgeClientEventListener {
         event.register(grassColor,
                 TFGBlocks_Earth.PLANTS.get(TFGPlant.RED_OAT_GRASS).get());
     }
-
-    // These are taken from TFC Aged Alcohol
-
-    private static Component getTooltip(MobEffectInstance effectInstance) {
-        return Component.literal(effectInstance.getEffect().getDisplayName().getString()
-                + displayedPotency(effectInstance.getAmplifier()) + "(" + formatDuration(effectInstance) + ")").withStyle(effectInstance.getEffect().getCategory().getTooltipFormatting());
-    }
-
-    private static String displayedPotency(int amplifier) {
-        return switch (amplifier + 1) {
-            case 2 -> " II ";
-            case 3 -> " III ";
-            default -> " ";
-        };
-    }
-
-    private static String formatDuration(MobEffectInstance effect) {
-        return StringUtil.formatTickDuration(Mth.floor(effect.getDuration()));
-    }
-
 }

--- a/src/main/java/su/terrafirmagreg/core/client/TFGItemTooltipHelpers.java
+++ b/src/main/java/su/terrafirmagreg/core/client/TFGItemTooltipHelpers.java
@@ -1,0 +1,79 @@
+package su.terrafirmagreg.core.client;
+
+import net.dries007.tfc.util.Drinkable;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.Mth;
+import net.minecraft.util.StringUtil;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
+import su.terrafirmagreg.core.TFGCore;
+import su.terrafirmagreg.core.common.data.capabilities.ILargeEgg;
+import su.terrafirmagreg.core.common.data.capabilities.LargeEggCapability;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
+@OnlyIn(Dist.CLIENT)
+public class TFGItemTooltipHelpers {
+    private static final TagKey<Fluid> TFC_DRINKABLE_TAG = TagKey.create(Registries.FLUID, ResourceLocation.fromNamespaceAndPath("tfc", "drinkables"));
+
+    @SuppressWarnings({ "deprecation", "ConstantConditions" })
+    @SubscribeEvent
+    public static void onItemTooltip(ItemTooltipEvent event) {
+        final ItemStack stack = event.getItemStack();
+        final List<Component> text = event.getToolTip();
+        if (!stack.isEmpty()) {
+            final @Nullable ILargeEgg egg = LargeEggCapability.get(stack);
+            if (egg != null) {
+                egg.addTooltipInfo(text);
+                return;
+            }
+
+            var foodProperties = stack.getFoodProperties(event.getEntity());
+            if (foodProperties != null) {
+                foodProperties.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(effect.getFirst())));
+            }
+
+            stack.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM).ifPresent(capability -> {
+                FluidStack fluidStack = capability.getFluidInTank(0);
+                if (fluidStack.getFluid().is(TFC_DRINKABLE_TAG) && !ForgeRegistries.FLUIDS.getKey(fluidStack.getFluid()).getNamespace().equals("tfcagedalcohol")) {
+                    Drinkable drink = Drinkable.get(fluidStack.getFluid());
+                    if (drink != null) {
+                        drink.getEffects().forEach(effect -> event.getToolTip().add(getTooltip(new MobEffectInstance(effect.type(), effect.duration(), effect.amplifier()))));
+                    }
+                }
+            });
+        }
+    }
+
+    // These are taken from TFC Aged Alcohol
+    private static Component getTooltip(MobEffectInstance effectInstance) {
+        return Component.literal(effectInstance.getEffect().getDisplayName().getString()
+                + displayedPotency(effectInstance.getAmplifier()) + "(" + formatDuration(effectInstance) + ")").withStyle(effectInstance.getEffect().getCategory().getTooltipFormatting());
+    }
+
+    private static String displayedPotency(int amplifier) {
+        return switch (amplifier + 1) {
+            case 2 -> " II ";
+            case 3 -> " III ";
+            default -> " ";
+        };
+    }
+
+    private static String formatDuration(MobEffectInstance effect) {
+        return StringUtil.formatTickDuration(Mth.floor(effect.getDuration()));
+    }
+}


### PR DESCRIPTION
### What is the new behavior?
Moves my tooltip code for drink effects into its own separate file due to causing somewhat random crashes on startup. 

### Additional information
I intend to add more functionality later so will move other item tooltip code into same file later. For now this is a hotfix to prevent random crashes.