### PR TITLE
Fix superglue offhand scythe dupe

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/create/SuperGlueHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/create/SuperGlueHandlerMixin.java
@@ -1,0 +1,30 @@
+package su.terrafirmagreg.core.mixins.common.create;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.simibubi.create.content.contraptions.glue.SuperGlueHandler;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.event.level.BlockEvent;
+
+@Mixin(value = SuperGlueHandler.class, remap = false)
+public abstract class SuperGlueHandlerMixin {
+    /**
+     * @author Ujhik
+     * @reason To add exclusions to the superglue offhand behavior of creating a glue region when using main hand items
+     */
+    @Inject(method = "glueInOffHandAppliesOnBlockPlace", at = @At("HEAD"), cancellable = true)
+    private static void tfg$superGlueOffhandExclusions(BlockEvent.EntityPlaceEvent event, BlockPos pos, Player player, CallbackInfo ci) {
+        ItemStack itemStackMainHand = player.getMainHandItem();
+        if (itemStackMainHand.is(Tags.Items.SEEDS) || itemStackMainHand.is(ItemTags.TOOLS)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/HarvestCropsBehaviorMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/HarvestCropsBehaviorMixin.java
@@ -193,10 +193,6 @@ public abstract class HarvestCropsBehaviorMixin {
                 drop.shrink(1);
                 removedStick = true;
             }
-
-            // Generating drops
-            if (!drop.isEmpty())
-                Block.popResource(level, targetPos, drop);
         }
 
         // If not removed stick, try to remove one from inventory
@@ -215,6 +211,14 @@ public abstract class HarvestCropsBehaviorMixin {
         FluidState fluidState = level.getFluidState(targetPos);
         level.setBlockAndUpdate(targetPos, fluidState.createLegacyBlock());
 
+        BlockState stateAfter = level.getBlockState(targetPos);
+        Block blockAfter = stateAfter.getBlock();
+
+        // If break failed we exit
+        boolean broken = blockAfter != blockState.getBlock();
+        if (!broken)
+            return false;
+
         // Replanting in the next tick to ensure multiblock crop tops break
         if (cropSeed != null) {
             ItemStack finalCropSeed = cropSeed;
@@ -228,9 +232,25 @@ public abstract class HarvestCropsBehaviorMixin {
                             Direction.UP,
                             targetPos,
                             false));
+
+            BlockState previousBlockState = blockState;
             int ticksDelay = 1;
             level.getServer().tell(new net.minecraft.server.TickTask(level.getServer().getTickCount() + ticksDelay,
-                    () -> finalCropSeed.useOn(plantCtx)));
+                    () -> {
+                        BlockState checkState = level.getBlockState(targetPos);
+                        boolean trulyBroken = checkState.getBlock() != previousBlockState.getBlock();
+
+                        if (!trulyBroken)
+                            return;
+
+                        // Spawning drops
+                        for (ItemStack drop : drops) {
+                            if (!drop.isEmpty())
+                                Block.popResource(level, targetPos, drop);
+                        }
+
+                        finalCropSeed.useOn(plantCtx);
+                    }));
 
             // Adding the stick when needed. Couldn't add it simulating player right click because the "use" method of ClimbingCropBlock internally gets the item in hand instead of the item in context
             ticksDelay += 1;

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -56,6 +56,7 @@
         "common.create.ProcessingRecipeMixin",
         "common.create.SchematicPrinterMixin",
         "common.create.StationBlockEntityMixin",
+        "common.create.SuperGlueHandlerMixin",
         "common.create.WaterWheelBlockEntityMixin",
         "common.create.WaterWheelBlockMixin",
         "common.create.WindmillBearingBlockEntityMixin",


### PR DESCRIPTION
## What is the new behavior?
Fixes superglue offhand scythe dupe by:
- Scythe behavior: Only dropping crop loot when successfully checking crop block has been broken in the next tick 
- Superglue offhand behavior: Excluding tools and seeds from executing this behavior (scythe included in tools)

closes TerraFirmaGreg-Team/Modpack-Modern#3534