### PR TITLE
Pot and Vat Fluid Mixins

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/firmalife/VatRecipeMatchesMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/firmalife/VatRecipeMatchesMixin.java
@@ -12,6 +12,7 @@ import com.eerussianguy.firmalife.common.recipes.VatRecipe;
 
 import net.dries007.tfc.common.recipes.ingredients.FluidStackIngredient;
 import net.dries007.tfc.common.recipes.ingredients.ItemStackIngredient;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.fluids.FluidStack;
 
 /**
@@ -35,7 +36,7 @@ public abstract class VatRecipeMatchesMixin {
      * The recipe's assembleOutputs() will calculate the correct multiplier.
      */
     @Inject(method = "matches(Lcom/eerussianguy/firmalife/common/blockentities/VatBlockEntity$VatInventory;Lnet/minecraft/world/level/Level;)Z", at = @At("HEAD"), cancellable = true)
-    private void tfg$matchesWithMinimumFluid(VatBlockEntity.VatInventory container, net.minecraft.world.level.Level level, CallbackInfoReturnable<Boolean> cir) {
+    private void tfg$matchesWithMinimumFluid(VatBlockEntity.VatInventory container, Level level, CallbackInfoReturnable<Boolean> cir) {
         // Check if item matches.
         if (!inputItem.test(container.getStackInSlot(0))) {
             cir.setReturnValue(false);

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/firmalife/VatRecipeMatchesMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/firmalife/VatRecipeMatchesMixin.java
@@ -1,0 +1,60 @@
+package su.terrafirmagreg.core.mixins.common.firmalife;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.eerussianguy.firmalife.common.blockentities.VatBlockEntity;
+import com.eerussianguy.firmalife.common.recipes.VatRecipe;
+
+import net.dries007.tfc.common.recipes.ingredients.FluidStackIngredient;
+import net.dries007.tfc.common.recipes.ingredients.ItemStackIngredient;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * Modifies VatRecipe.matches() to check for minimum fluid amount instead of exact match.
+ * This allows vat recipes to work with extra fluid in the vat.
+ */
+@Mixin(value = VatRecipe.class, remap = false)
+public abstract class VatRecipeMatchesMixin {
+
+    @Shadow
+    @Final
+    private ItemStackIngredient inputItem;
+
+    @Shadow
+    @Final
+    private FluidStackIngredient inputFluid;
+
+    /**
+     * Replace the matches method to check for minimum fluid amount.
+     * Removes the restrictive ratio check from the original to allow excess fluid.
+     * The recipe's assembleOutputs() will calculate the correct multiplier.
+     */
+    @Inject(method = "matches(Lcom/eerussianguy/firmalife/common/blockentities/VatBlockEntity$VatInventory;Lnet/minecraft/world/level/Level;)Z", at = @At("HEAD"), cancellable = true)
+    private void tfg$matchesWithMinimumFluid(VatBlockEntity.VatInventory container, net.minecraft.world.level.Level level, CallbackInfoReturnable<Boolean> cir) {
+        // Check if item matches.
+        if (!inputItem.test(container.getStackInSlot(0))) {
+            cir.setReturnValue(false);
+            return;
+        }
+
+        // Check if fluid type matches.
+        FluidStack containerFluid = container.getFluidInTank(0);
+        if (!inputFluid.ingredient().test(containerFluid.getFluid())) {
+            cir.setReturnValue(false);
+            return;
+        }
+
+        // Check for minimum fluid amount.
+        if (containerFluid.getAmount() < inputFluid.amount()) {
+            cir.setReturnValue(false);
+            return;
+        }
+
+        cir.setReturnValue(true);
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/PotBlockEntityMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/PotBlockEntityMixin.java
@@ -4,15 +4,23 @@ import javax.annotation.Nullable;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.dries007.tfc.common.blockentities.PotBlockEntity;
+import net.dries007.tfc.common.recipes.JamPotRecipe;
 import net.dries007.tfc.common.recipes.PotRecipe;
+import net.dries007.tfc.common.recipes.SoupPotRecipe;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.templates.FluidTank;
 
 /**
- * Makes pot recipes consume only the required fluid amount instead of all fluid in the pot.
+ * Makes pot recipes consume only the required fluid amount and preserve remainder,
+ * Unless the recipe produces a fluid output or is a jam/soup recipe.
  */
 @Mixin(value = PotBlockEntity.class, remap = false)
 public abstract class PotBlockEntityMixin {
@@ -21,24 +29,69 @@ public abstract class PotBlockEntityMixin {
     @Nullable
     private PotRecipe cachedRecipe;
 
+    @Unique
+    private FluidStack tfg$savedInputFluid = FluidStack.EMPTY;
+
+    @Unique
+    private int tfg$requiredAmount = 0;
+
+    @Unique
+    private boolean tfg$isSoupOrJam = false;
+
     /**
-     * Intercepts the tank.setFluid(FluidStack.EMPTY) call in handleCooking()
-     * and instead drains only the required amount specified by the recipe.
+     * Save the input fluid state before the recipe clears it.
+     * Also check if this is a soup or jam recipe.
      */
     @Redirect(method = "handleCooking", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fluids/capability/templates/FluidTank;setFluid(Lnet/minecraftforge/fluids/FluidStack;)V"))
-    private void tfg$consumeOnlyRequiredFluid(net.minecraftforge.fluids.capability.templates.FluidTank tank, FluidStack empty) {
+    private void tfg$saveInputFluidBeforeClear(FluidTank tank, FluidStack empty) {
+        assert cachedRecipe != null : "cachedRecipe should not be null when handleCooking completes a recipe";
 
-        assert cachedRecipe != null;
-        var fluidIngredient = cachedRecipe.getFluidIngredient();
-        int requiredAmount = fluidIngredient.amount();
-        FluidStack currentFluid = tank.getFluid();
-        int remainingAmount = Math.max(0, currentFluid.getAmount() - requiredAmount);
+        tfg$savedInputFluid = tank.getFluid().copy();
+        tfg$requiredAmount = cachedRecipe.getFluidIngredient().amount();
+        tfg$isSoupOrJam = cachedRecipe instanceof SoupPotRecipe || cachedRecipe instanceof JamPotRecipe;
 
-        if (remainingAmount > 0) {
-            FluidStack remainingFluid = new FluidStack(currentFluid.getFluid(), remainingAmount);
-            tank.setFluid(remainingFluid);
-        } else {
-            tank.setFluid(FluidStack.EMPTY);
+        tank.setFluid(FluidStack.EMPTY);
+    }
+
+    /**
+     * After output.onFinish() is called, check if it added fluid.
+     * If not, restore the remainder from our saved state.
+     * Soup and Jam recipes always void remainder.
+     */
+    @Inject(method = "handleCooking", at = @At(value = "INVOKE", target = "Lnet/dries007/tfc/common/recipes/PotRecipe$Output;onFinish(Lnet/dries007/tfc/common/blockentities/PotBlockEntity$PotInventory;)V", shift = At.Shift.AFTER))
+    private void tfg$restoreRemainderIfNoOutputFluid(CallbackInfo ci) {
+        if (tfg$isSoupOrJam) {
+            tfg$savedInputFluid = FluidStack.EMPTY;
+            tfg$requiredAmount = 0;
+            tfg$isSoupOrJam = false;
+            return;
         }
+
+        PotBlockEntity self = (PotBlockEntity) (Object) this;
+        PotBlockEntity.PotInventory inventory = (PotBlockEntity.PotInventory) self.getCapability(
+                net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER).orElseThrow(() -> new IllegalStateException("Pot should have inventory"));
+
+        FluidStack currentFluid = inventory.getFluidInTank(0);
+
+        if (!currentFluid.isEmpty()) {
+            tfg$savedInputFluid = FluidStack.EMPTY;
+            tfg$isSoupOrJam = false;
+            return;
+        }
+
+        // No output fluid, restore remainder from saved input.
+        if (!tfg$savedInputFluid.isEmpty()) {
+            int remainingAmount = Math.max(0, tfg$savedInputFluid.getAmount() - tfg$requiredAmount);
+
+            if (remainingAmount > 0) {
+                FluidStack remainingFluid = new FluidStack(tfg$savedInputFluid.getFluid(), remainingAmount);
+                inventory.getFluidHandler().fill(remainingFluid, IFluidHandler.FluidAction.EXECUTE);
+            }
+        }
+
+        // Clear saved state.
+        tfg$savedInputFluid = FluidStack.EMPTY;
+        tfg$requiredAmount = 0;
+        tfg$isSoupOrJam = false;
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/PotBlockEntityMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/PotBlockEntityMixin.java
@@ -1,0 +1,44 @@
+package su.terrafirmagreg.core.mixins.common.tfc;
+
+import javax.annotation.Nullable;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.dries007.tfc.common.blockentities.PotBlockEntity;
+import net.dries007.tfc.common.recipes.PotRecipe;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * Makes pot recipes consume only the required fluid amount instead of all fluid in the pot.
+ */
+@Mixin(value = PotBlockEntity.class, remap = false)
+public abstract class PotBlockEntityMixin {
+
+    @Shadow
+    @Nullable
+    private PotRecipe cachedRecipe;
+
+    /**
+     * Intercepts the tank.setFluid(FluidStack.EMPTY) call in handleCooking()
+     * and instead drains only the required amount specified by the recipe.
+     */
+    @Redirect(method = "handleCooking", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fluids/capability/templates/FluidTank;setFluid(Lnet/minecraftforge/fluids/FluidStack;)V"))
+    private void tfg$consumeOnlyRequiredFluid(net.minecraftforge.fluids.capability.templates.FluidTank tank, FluidStack empty) {
+
+        assert cachedRecipe != null;
+        var fluidIngredient = cachedRecipe.getFluidIngredient();
+        int requiredAmount = fluidIngredient.amount();
+        FluidStack currentFluid = tank.getFluid();
+        int remainingAmount = Math.max(0, currentFluid.getAmount() - requiredAmount);
+
+        if (remainingAmount > 0) {
+            FluidStack remainingFluid = new FluidStack(currentFluid.getFluid(), remainingAmount);
+            tank.setFluid(remainingFluid);
+        } else {
+            tank.setFluid(FluidStack.EMPTY);
+        }
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -186,6 +186,7 @@
         "common.tfc.LivestockAiMixin",
         "common.tfc.MoldCapabilityMixin",
         "common.tfc.OverworldClimateModelMixin",
+        "common.tfc.PotBlockEntityMixin",
         "common.tfc.RockDataMixin",
         "common.tfc.SupportMixin",
         "common.tfc.TFCAnimalBrainMixin",

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -70,6 +70,7 @@
         "common.firmalife.LargePlanterBlockEntityOxygenMixin",
         "common.firmalife.MixinFoodShelfBlockEntity",
         "common.firmalife.MixinGreenhousePortBlock",
+        "common.firmalife.VatRecipeMatchesMixin",
         "common.flywheel.AnimatedBlazeBurnerMixin",
         "common.forge.CapabilityProviderMixin",
         "common.forge.ForgeConfigSpecMixin",


### PR DESCRIPTION
Allows both the campfire pot and stove vat to not need exact fluid quantities for recipes and wont void excess fluid inputs. It will check to make sure there is the minimum amount of fluid available and then subtract that from the total amount of fluid in the container leaving the remainder behind. Unless the recipe outputs a fluid. Or is a pot jam/ soup recipe.