### PR TITLE
Fix canoe sawing with GT saws

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/item/behavior/CanoeCreatorBehavior.java
+++ b/src/main/java/su/terrafirmagreg/core/common/item/behavior/CanoeCreatorBehavior.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.ToolActions;
 
 public final class CanoeCreatorBehavior implements IToolBehavior {
@@ -32,8 +33,11 @@ public final class CanoeCreatorBehavior implements IToolBehavior {
     public InteractionResult onItemUse(UseOnContext context) {
         Level level = context.getLevel();
         BlockPos pos = context.getClickedPos();
-        level.getBlockState(pos).getToolModifiedState(context, ToolActions.AXE_STRIP, false);
-
+        BlockState modified = level.getBlockState(pos).getToolModifiedState(context, ToolActions.AXE_STRIP, false);
+        if (modified != null) {
+            level.setBlock(pos, modified, 11);
+            return InteractionResult.sidedSuccess(level.isClientSide);
+        }
         return InteractionResult.PASS;
     }
 


### PR DESCRIPTION
Fixes [#3625](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3625)

## Bug details:
TFC saws are actually registered as axes. This allows TFC saws to trigger the canoe sawing.

To mimic this, in TFG we have a GTToolTypeMixin that adds a CanoeCreatorBehavior to GT Saws, which triggers its own getToolModifiedState.

During testing of the original canoe fix, I used runClient to be able to run 2 clients. But runClient doesn't have GT saws, so I never used this path, in fact I didn't even know it existed.

Because canoe carving was always done as a side effect with setBlock, this CanoeCreatorBehavior path never need to do much. In fact, it didn't even consume the right click, always returning Interaction.PASS.

But with my fix to use setFinalState, the CanoeCreatorBehavior needs to properly handle the modified BlockState.

## Fix details:
Handle the modified BlockState, consume the interaction.

## Other details:
- I'm now not sure if the canoe carving is actually synced properly to bystanders anymore, because I can only test the TFC/vanilla path in runClient. As far as I can tell I'm doing the same things now in my code, but the bystander sync part is hard to test. At least the sawing and the axing works fine for the player doing the carving.

- For player questions on the current broken version, if you use a saw in your main hand and an axe in your offhand, you can still saw the canoe since the offhand axe handler path happens to apply the blockstate.