### PR TITLE
Don't load chunks when checking for supports

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/perf/SupportCache.java
+++ b/src/main/java/su/terrafirmagreg/core/common/perf/SupportCache.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.EmptyLevelChunk;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainer;
 
@@ -65,7 +66,10 @@ public class SupportCache {
 
                 // Build cache if needed
                 if (!scannedChunks.contains(key)) {
-                    scanChunk(level, cx, cz);
+                    if (!scanChunk(level, cx, cz)) {
+                        // Chunk not loaded, pretend it's supported
+                        return true;
+                    }
                 }
 
                 Map<BlockPos, SupportEntry> entries = chunkSupports.get(key);
@@ -94,14 +98,14 @@ public class SupportCache {
     /**
      * Find all support blocks in a chunk.
      * Does a very low-level scan of the raw PalettedContainer data to make things fast.
+     * @return true if the chunk was available and scanned, false if it wasn't loaded
      */
-    private void scanChunk(Level level, int cx, int cz) {
+    private boolean scanChunk(Level level, int cx, int cz) {
         long key = ChunkPos.asLong(cx, cz);
 
-        ChunkAccess chunk = level.getChunkSource().getChunk(cx, cz, ChunkStatus.FULL, true);
-        if (chunk == null || chunk instanceof EmptyLevelChunk)
-            // Clientside returns EmptyLevelChunk for unloaded chunks, we don't want to scan those or mark them as scanned
-            return;
+        ChunkAccess chunk = level.getChunkSource().getChunk(cx, cz, ChunkStatus.FULL, false);
+        if (!(chunk instanceof LevelChunk) || chunk instanceof EmptyLevelChunk)
+            return false;
 
         scannedChunks.add(key);
 
@@ -149,6 +153,7 @@ public class SupportCache {
         if (!entries.isEmpty()) {
             chunkSupports.put(key, entries);
         }
+        return true;
     }
 
     /**
@@ -178,7 +183,10 @@ public class SupportCache {
             for (int cz = minCZ; cz <= maxCZ; cz++) {
                 long key = ChunkPos.asLong(cx, cz);
                 if (!scannedChunks.contains(key)) {
-                    scanChunk(level, cx, cz);
+                    if (!scanChunk(level, cx, cz)) {
+                        // Chunk not loaded, pretend it's supported
+                        return Set.of();
+                    }
                 }
                 Map<BlockPos, SupportEntry> entries = chunkSupports.get(key);
                 if (entries == null)


### PR DESCRIPTION
## Previous behavior
If a block wants to landslide, it would load surrounding chunks to see if there's a support in them. This would give correct behavior at all times.

## New behavior
If the surrounding chunks aren't already loaded, just pretend it's always supported. This saves processing, but it means that blocks at the edge of your render distance might not landslide even if they should. It's no big deal though since they might landslide anyway if you get closer to them and they get another neighbor tick.

## Reason
Hopefully it helps a bit with not loading too many chunks. This is mostly a guess because I'm having trouble getting a consistent profiling of the cpu/mem problems, but it doesn't hurt to be conservative this way anyway.