### PR TITLE
Cache noise objects instead of recreating every call

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/noise/ShoreNoise.java
+++ b/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/noise/ShoreNoise.java
@@ -22,13 +22,14 @@ public final class ShoreNoise {
     // Typical monoslope beach
     public static ShoreNoiseSampler sandyBeach(Seed seed) {
         return new ShoreNoiseSampler() {
+            final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
             double sandHeight, weight;
 
             @Override
             public double setColumnAndSampleHeight(double heightIn, int x, int z, double oceanWeight, double landWeight, double shoreWeight, double thisWeight, BiomeExtension biome,
                     double shoreHeight, double normalHeight) {
 
-                this.sandHeight = ShoreNoise.simpleBeach(seed, x, z, heightIn, landWeight, oceanWeight);
+                this.sandHeight = ShoreNoise.simpleBeach(tideLevelNoise.noise(x, z), heightIn, landWeight, oceanWeight);
                 this.weight = thisWeight;
 
                 return sandHeight;
@@ -52,6 +53,7 @@ public final class ShoreNoise {
         return new ShoreNoiseSampler() {
             final Noise2D bankNoise = new OpenSimplex2D(seed.seed()).spread(0.03).abs().scaled(-1, 8);
             final Noise3D cliffNoise = TFGBiomeNoise.cliffNoise(seed);
+            final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
 
             final double cliffBaseWeight = 0.25;
             final double cliffTopWeight = 0.45;
@@ -70,9 +72,9 @@ public final class ShoreNoise {
                 this.x = x;
                 this.z = z;
                 this.landWeight = landWeight;
-                this.sandHeight = ShoreNoise.simpleBeachNoLandBlend(seed, x, z, heightIn, landWeight, oceanWeight);
+                this.sandHeight = ShoreNoise.simpleBeachNoLandBlend(tideLevelNoise.noise(x, z), heightIn, landWeight, oceanWeight);
                 this.yTop = heightIn;
-                final double tideLevelAtOcean = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z) - 4;
+                final double tideLevelAtOcean = tideLevelNoise.noise(x, z) - 4;
 
                 final double shoreBankHeight = bankNoise.noise(x, z) + sandHeight;
 
@@ -116,6 +118,7 @@ public final class ShoreNoise {
         return new ShoreNoiseSampler() {
             final OpenSimplex2D warpNoise = new OpenSimplex2D(seed.seed()).scaled(-10, 10).spread(0.05);
             final Noise2D duneNoise = new OpenSimplex2D(seed.seed()).spread(0.03).abs().scaled(-2, 6.5).warped(warpNoise);
+            final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
 
             double duneHeight;
             double sandHeight;
@@ -123,8 +126,8 @@ public final class ShoreNoise {
             @Override
             public double setColumnAndSampleHeight(double heightIn, int x, int z, double oceanWeight, double landWeight, double shoreWeight, double thisWeight, BiomeExtension biome,
                     double shoreHeight, double normalHeight) {
-                this.sandHeight = ShoreNoise.simpleBeach(seed, x, z, heightIn, landWeight, oceanWeight);
-                final double tideLevelAtOcean = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z) - 4;
+                this.sandHeight = ShoreNoise.simpleBeach(tideLevelNoise.noise(x, z), heightIn, landWeight, oceanWeight);
+                final double tideLevelAtOcean = tideLevelNoise.noise(x, z) - 4;
 
                 final double fullDuneHeight = duneNoise.noise(x, z) + sandHeight;
                 if (oceanWeight > 0) {
@@ -160,6 +163,7 @@ public final class ShoreNoise {
                     new OpenSimplex2D(seed.seed() + 492L).octaves(3).spread(0.09),
                     -1, 0, -5, 0);
             private final Noise3D caveNoise = TFGBiomeNoise.cliffNoise(seed).scaled(0, 0.12);
+            private final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
 
             final double topShelfEdge = 0.7;
             final double midShelfEdge = 0.35;
@@ -177,7 +181,7 @@ public final class ShoreNoise {
             @Override
             public double setColumnAndSampleHeight(double heightIn, int x, int z, double oceanWeight, double landWeight, double shoreWeight, double thisWeight, BiomeExtension biome,
                     double shoreHeight, double normalHeight) {
-                tideLevel = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z);
+                tideLevel = tideLevelNoise.noise(x, z);
                 sandHeight = ShoreNoise.simpleBeach(tideLevel, heightIn, landWeight, oceanWeight);
                 this.x = x;
                 this.z = z;
@@ -235,6 +239,7 @@ public final class ShoreNoise {
             private final Noise2D tidepoolNoise = TFGNoiseHelpers.clampedScaled(
                     new OpenSimplex2D(seed.seed() + 492L).octaves(3).spread(0.09),
                     -1, 0, -5, 0);
+            private final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
 
             private final TFGCellular2D cellularNoise = new TFGCellular2D(seed.seed() + 323L).spread(0.022);
             private final Noise2D punchbowlCarvingNoise = (x, z) -> {
@@ -266,7 +271,7 @@ public final class ShoreNoise {
             @Override
             public double setColumnAndSampleHeight(double heightIn, int x, int z, double oceanWeight, double landWeight, double shoreWeight, double thisWeight, BiomeExtension biome,
                     double shoreHeight, double normalHeight) {
-                final double tideLevel = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z);
+                final double tideLevel = tideLevelNoise.noise(x, z);
                 oceanEdgeHeight = tideLevel - 4;
                 this.x = x;
                 this.z = z;
@@ -393,6 +398,7 @@ public final class ShoreNoise {
             };
 
             final Noise3D cliffNoise = TFGBiomeNoise.cliffNoise(seed);
+            final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
 
             private double stackNoiseValue;
             private double sandHeight;
@@ -410,7 +416,7 @@ public final class ShoreNoise {
                 this.landWeight = landWeight;
                 this.oceanWeightFactor = Mth.clampedMap(oceanWeight, 0.1, 0.25, 1, 0);
 
-                this.tideLevel = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z);
+                this.tideLevel = tideLevelNoise.noise(x, z);
                 final double typicalBeachSandHeight = ShoreNoise.simpleBeach(tideLevel, heightIn, landWeight, oceanWeight);
                 // High-tide variants of this biome should completely swallow this beach
                 this.sandHeight = Mth.clampedMap(thisWeight, 0.5, 0.8, typicalBeachSandHeight, Math.min(typicalBeachSandHeight, tideLevel - 1));
@@ -512,6 +518,7 @@ public final class ShoreNoise {
 
             final Noise3D cliffNoise = TFGBiomeNoise.cliffNoise(seed);
             final Noise2D lowerTerraceNoise = TFGBiomeNoise.lowerTerraceNoise(seed);
+            final Noise2D tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
 
             private double oceanWeight;
             private double lowerTerraceHeight;
@@ -526,7 +533,7 @@ public final class ShoreNoise {
                 this.z = z;
                 this.oceanWeight = oceanWeight;
                 this.lowerTerraceHeight = lowerTerraceNoise.noise(x, z);
-                this.sandHeight = ShoreNoise.simpleBeach(seed, x, z, heightIn, landWeight, oceanWeight);
+                this.sandHeight = ShoreNoise.simpleBeach(tideLevelNoise.noise(x, z), heightIn, landWeight, oceanWeight);
 
                 return lowerTerraceHeight;
             }
@@ -568,11 +575,6 @@ public final class ShoreNoise {
         return Math.min(curve, topWidth);
     }
 
-    private static double simpleBeach(Seed seed, int x, int z, double heightIn, double landWeight, double oceanWeight) {
-        final double tideLevel = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z);
-        return simpleBeach(tideLevel, heightIn, landWeight, oceanWeight);
-    }
-
     private static double simpleBeach(double tideLevel, double heightIn, double landWeight, double oceanWeight) {
 
         // Basic heights that the shore height will approach at edges with other biomes
@@ -590,9 +592,7 @@ public final class ShoreNoise {
         }
     }
 
-    private static double simpleBeachNoLandBlend(Seed seed, int x, int z, double heightIn, double landWeight, double oceanWeight) {
-        final double tideLevel = TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z);
-
+    private static double simpleBeachNoLandBlend(double tideLevel, double heightIn, double landWeight, double oceanWeight) {
         // Basic heights that the shore height will approach at edges with other biomes
         final double simpleShoreSelfHeight = tideLevel - 1;
         final double simpleShoreOceanHeight = tideLevel - 4;

--- a/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/surface_builders/ShieldVolcanoSurfaceBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/surface_builders/ShieldVolcanoSurfaceBuilder.java
@@ -25,6 +25,8 @@ public class ShieldVolcanoSurfaceBuilder implements SurfaceBuilder {
     private final boolean hasLavaFlows;
     private final boolean isSandy;
     private final long seed;
+    private final Noise2D lavaFlowMaterialNoise;
+    private final Noise2D lavaFlowNoise;
     private final TFGSimpleSurfaceStates simpleStates;
     private final TFGComplexSurfaceStates complexStates;
 
@@ -32,6 +34,8 @@ public class ShieldVolcanoSurfaceBuilder implements SurfaceBuilder {
         this.hasLavaFlows = hasLavaFlows;
         this.isSandy = isSandy;
         this.seed = seed;
+        this.lavaFlowMaterialNoise = TFGBiomeNoise.lavaFlowMaterial(seed);
+        this.lavaFlowNoise = TFGBiomeNoise.lavaFlow(seed);
         this.simpleStates = TFGSimpleSurfaceStates.INSTANCE();
         this.complexStates = TFGComplexSurfaceStates.INSTANCE();
     }
@@ -60,10 +64,8 @@ public class ShieldVolcanoSurfaceBuilder implements SurfaceBuilder {
         if (!hasLavaFlows) {
             buildSurface(context, startY, endY, top, mid, bot, underwater);
         } else {
-            final Noise2D smoothNoise = TFGBiomeNoise.lavaFlowMaterial(seed);
-            final double noiseValue = smoothNoise.noise(x, z);
-            final Noise2D lavaFlows = TFGBiomeNoise.lavaFlow(seed);
-            final double flowValue = lavaFlows.noise(x, z);
+            final double noiseValue = lavaFlowMaterialNoise.noise(x, z);
+            final double flowValue = lavaFlowNoise.noise(x, z);
 
             if (flowValue < 0.40)
                 buildSurface(context, startY, endY, top, mid, bot, underwater);

--- a/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/surface_builders/ShoreAndOceanSurfaceBuilder.java
+++ b/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/surface_builders/ShoreAndOceanSurfaceBuilder.java
@@ -76,6 +76,9 @@ public class ShoreAndOceanSurfaceBuilder implements SurfaceBuilder {
     private final NormalNoise icebergSurfaceNoise;
     private final Noise2D patternedNoise;
 
+    private final Noise2D tideLevelNoise;
+    private final Noise2D lavaFlowMaterialNoise;
+    private final Noise2D lavaFlowNoise;
     private final TFGSimpleSurfaceStates simpleStates = TFGSimpleSurfaceStates.INSTANCE();
 
     /**
@@ -99,6 +102,9 @@ public class ShoreAndOceanSurfaceBuilder implements SurfaceBuilder {
         this.icebergPillarRoofNoise = NormalNoise.create(random, new NormalNoise.NoiseParameters(-3, 1.0D));
         this.icebergSurfaceNoise = NormalNoise.create(random, new NormalNoise.NoiseParameters(-6, 1.0D, 1.0D, 1.0D));
         this.patternedNoise = TFGBiomeNoise.seaIceNoise(seed.forkStable().next());
+        this.tideLevelNoise = TFGBiomeNoise.shoreTideLevelNoise(seed);
+        this.lavaFlowMaterialNoise = TFGBiomeNoise.lavaFlowMaterial(seed.seed());
+        this.lavaFlowNoise = TFGBiomeNoise.lavaFlow(seed.seed());
     }
 
     @Override
@@ -106,7 +112,7 @@ public class ShoreAndOceanSurfaceBuilder implements SurfaceBuilder {
         final BlockPos pos = context.pos();
         final int x = pos.getX();
         final int z = pos.getZ();
-        final int tideLevel = (int) TFGBiomeNoise.shoreTideLevelNoise(seed).noise(x, z);
+        final int tideLevel = (int) tideLevelNoise.noise(x, z);
         final int sandHeightAbsolute = tideLevel + sandHeight;
         final int seaLevel = context.getSeaLevel();
 
@@ -151,10 +157,8 @@ public class ShoreAndOceanSurfaceBuilder implements SurfaceBuilder {
      * but using different materials
      */
     private void buildLavaFlowSurface(SurfaceBuilderContext context, int startY, int endY, int x, int z) {
-        final Noise2D smoothNoise = TFGBiomeNoise.lavaFlowMaterial(seed.seed());
-        final double noiseValue = smoothNoise.noise(x, z);
-        final Noise2D lavaFlows = TFGBiomeNoise.lavaFlow(seed.seed());
-        final double flowValue = lavaFlows.noise(x, z);
+        final double noiseValue = lavaFlowMaterialNoise.noise(x, z);
+        final double flowValue = lavaFlowNoise.noise(x, z);
 
         if (flowValue < 0.40)
             TFGNormalSurfaceBuilder.INSTANCE.buildSurface(context, startY, endY, surface, surface, subsurface, surface, surface);

--- a/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/surface_states/TFGComplexSurfaceStates.java
+++ b/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/surface_states/TFGComplexSurfaceStates.java
@@ -27,6 +27,9 @@ import su.terrafirmagreg.core.world.new_ow_wg.RockSettingsHelpers;
 // Split from TFC's SurfaceStates because of looping references.
 
 public class TFGComplexSurfaceStates {
+    private static final Noise2D SAND_VARIANT_NOISE = new OpenSimplex2D(36263276L).octaves(5).spread(0.0003f).abs();
+    private static final Noise2D SAND_GRAVEL_BEACH_NOISE = new OpenSimplex2D(124154L).octaves(3).spread(0.00002f);
+
     private static TFGComplexSurfaceStates instance = null;
 
     public static TFGComplexSurfaceStates INSTANCE() {
@@ -103,7 +106,7 @@ public class TFGComplexSurfaceStates {
                 final BlockPos pos = context.pos();
                 final int x = pos.getX();
                 final int z = pos.getZ();
-                final float variantNoiseValue = (float) sandVariantNoise().noise(x, z);
+                final float variantNoiseValue = (float) SAND_VARIANT_NOISE.noise(x, z);
                 if (variantNoiseValue > 0.55)
                     return RARE_SHORE_SAND.getState(context);
                 else if (variantNoiseValue > 0.2)
@@ -144,7 +147,7 @@ public class TFGComplexSurfaceStates {
                 final BlockPos pos = context.pos();
                 final int x = pos.getX();
                 final int z = pos.getZ();
-                final float variantNoiseValue = (float) sandGravelBeachNoise().noise(x, z);
+                final float variantNoiseValue = (float) SAND_GRAVEL_BEACH_NOISE.noise(x, z);
                 final double gravelCutoff = Mth.clampedMap(context.averageTemperature(), -15, 25, -0.7, 0.7);
                 return (variantNoiseValue > gravelCutoff ? SurfaceStates.GRAVEL : SHORE_SAND).getState(context);
             }
@@ -194,7 +197,7 @@ public class TFGComplexSurfaceStates {
                 final BlockPos pos = context.pos();
                 final int x = pos.getX();
                 final int z = pos.getZ();
-                final float variantNoiseValue = (float) sandVariantNoise().noise(x, z);
+                final float variantNoiseValue = (float) SAND_VARIANT_NOISE.noise(x, z);
                 if (variantNoiseValue > 0.8)
                     return RARE_SHORE_SANDSTONE.getState(context);
                 else if (variantNoiseValue > 0.4)
@@ -212,18 +215,11 @@ public class TFGComplexSurfaceStates {
                 final BlockPos pos = context.pos();
                 final int x = pos.getX();
                 final int z = pos.getZ();
-                final float variantNoiseValue = (float) sandGravelBeachNoise().noise(x, z);
+                final float variantNoiseValue = (float) SAND_GRAVEL_BEACH_NOISE.noise(x, z);
                 final double gravelCutoff = Mth.clampedMap(context.averageTemperature(), -15, 25, -0.7, 0.7);
                 return (variantNoiseValue > gravelCutoff ? SurfaceStates.RAW : SHORE_SANDSTONE).getState(context);
             }
         };
     }
 
-    public static Noise2D sandVariantNoise() {
-        return new OpenSimplex2D(36263276L).octaves(5).spread(0.0003f).abs();
-    }
-
-    public static Noise2D sandGravelBeachNoise() {
-        return new OpenSimplex2D(124154L).octaves(3).spread(0.00002f);
-    }
 }


### PR DESCRIPTION
## Details
Cache the noise objects around shore generation. They're expensive to generate anew and they are the same every time, so it's good to cache them.

Shouldn't change anything in terms of behavior or determinism.

## Performance Testing
New Minecraft world, seed '1'
Wait 2 minutes for things to stabilize

`/forge generate 3642 77 1449 10000`
Time with stopwatch

#### Before:
run 1: 5:27
run 2: 5:33

#### With this PR:
run 1: 5:09
run 2: 5:05

So about a 10% improvement in CPU time, possibly also some improvement in memory GC pressure, varying depending on whether you hit a lot of shore chunks