### PR TITLE
Fix beardifier: Try filling column up to structure height instead of only to surfaceHeight

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/BeardifierAccessor.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/BeardifierAccessor.java
@@ -1,0 +1,15 @@
+package su.terrafirmagreg.core.mixins.common.minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.world.level.levelgen.Beardifier;
+
+import it.unimi.dsi.fastutil.objects.ObjectListIterator;
+
+@Mixin(Beardifier.class)
+public interface BeardifierAccessor {
+
+    @Accessor("pieceIterator")
+    ObjectListIterator<Beardifier.Rigid> tfg$getPieceIterator();
+}

--- a/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/chunk/TFGChunkNoiseFiller.java
+++ b/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/chunk/TFGChunkNoiseFiller.java
@@ -39,6 +39,7 @@ import net.minecraft.world.level.material.Fluids;
 
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 
+import su.terrafirmagreg.core.mixins.common.minecraft.BeardifierAccessor;
 import su.terrafirmagreg.core.world.new_ow_wg.biome.TFGBiomes;
 import su.terrafirmagreg.core.world.new_ow_wg.noise.CenteredFeatureBlendType;
 import su.terrafirmagreg.core.world.new_ow_wg.noise.CenteredFeatureNoiseSampler;
@@ -101,6 +102,9 @@ public class TFGChunkNoiseFiller extends TFGChunkHeightFiller {
     private final BiomeExtension[] localBiomesNoRivers; // 16x16, block pos resolution
     private final double[] localBiomeWeights; // 16x16, block pos resolution
 
+    // Beardifier max Y: the highest Y that any structure piece in the chunk extends to, used to extend fill range
+    private final int beardifierMaxY;
+
     // Current local position / context
     private double cellDeltaX, cellDeltaZ; // Delta within a noise cell
     private int lastCellZ; // Last cell Z, needed due to a quick in noise interpolator
@@ -129,6 +133,7 @@ public class TFGChunkNoiseFiller extends TFGChunkHeightFiller {
         this.airCarvingMask = chunk.getOrCreateCarvingMask(GenerationStep.Carving.AIR);
 
         this.beardifier = beardifier;
+        this.beardifierMaxY = computeBeardifierMaxY(beardifier);
         this.mutableDensityFunctionContext = new MutableDensityFunctionContext(new BlockPos.MutableBlockPos());
         this.riverWater = TFCFluids.RIVER_WATER.get().defaultFluidState();
         this.riverData = new RiverInfo[16 * 16];
@@ -156,6 +161,21 @@ public class TFGChunkNoiseFiller extends TFGChunkHeightFiller {
         this.localBiomes = new BiomeExtension[16 * 16];
         this.localBiomesNoRivers = new BiomeExtension[16 * 16];
         this.localBiomeWeights = new double[16 * 16];
+    }
+
+    /**
+     * Compute the maximum Y value of any structures in this chunk
+     * @return Max Y value, or Integer.MIN_VALUE if there are no structures.
+     */
+    private static int computeBeardifierMaxY(Beardifier beardifier) {
+        var iterator = ((BeardifierAccessor) beardifier).tfg$getPieceIterator();
+        int maxY = Integer.MIN_VALUE;
+        while (iterator.hasNext()) {
+            var rigid = iterator.next();
+            maxY = Math.max(maxY, rigid.box().maxY());
+        }
+        iterator.back(Integer.MAX_VALUE);
+        return maxY;
     }
 
     public TFCAquifer aquifer() {
@@ -326,7 +346,7 @@ public class TFGChunkNoiseFiller extends TFGChunkHeightFiller {
 
         final Flow flow = localBiome.hasRivers() ? calculateFlowAt(cellX, cellZ) : Flow.NONE;
 
-        final int maxFilledY = 1 + Math.max(heightNoiseValue, seaLevel);
+        final int maxFilledY = 1 + Math.max(Math.max(heightNoiseValue, seaLevel), beardifierMaxY);
         final int maxFilledCellY = Math.min(settings.cellCountY() - 1, 1 + Math.floorDiv(maxFilledY, settings.cellHeight()) - settings.firstCellY());
         final int maxFilledSectionY = Math.min(chunk.getSectionsCount() - 1, 1 + chunk.getSectionIndex(maxFilledY));
 

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -134,6 +134,7 @@
         "common.ldlib.ModularUIContainerMixin",
         "common.minecraft.AccessorChunkMap",
         "common.minecraft.AccessorMinecraftServer",
+        "common.minecraft.BeardifierAccessor",
         "common.minecraft.AccessorServerChunkCache",
         "common.minecraft.AxolotlMixin",
         "common.minecraft.BlazeMixin",


### PR DESCRIPTION
## Beardifier details
The beardifier works by changing the density under structures. BEARD_BOX affects up to 12 blocks under the structure, but it has a gradual falloff so practically it's much less (5 or so).

## Bug details
Most of the code was working fine. The only issue is that `TFGChunkNoiseFiller.fillColumn` only fills columns up to max(surfaceHeight, seaLevel), so the beardifier never got a chance to affect the air blocks above the surface.

Vanilla minecraft doesn't have this issue since it just runs on every Y value in the column by default.

## Fix details
For each chunk, we determine the max Y value of all structures from the beardifier via an accessor. Then we iterate up to that value if it's higher. The beardifier then does its normal job without us having to do anything. The actual surface height shouldn't be affected for columns where the beardifier doesn't touch it.

For cases where there's no structure, this doesn't add any meaningful computation cost.

## Other details
This fix can also apply to TFC 1.20 and 1.21. If I'm reading it right, they have the same issue.

This does not fix structures spawning in rivers, or aqueducts not getting enough air inside mountains or not extending the legs all the way in some cases.