### PR TITLE
Fix beardifier plateaus: Force terrain noise slightly negative above normal surface height.

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/chunk/TFGChunkNoiseFiller.java
+++ b/src/main/java/su/terrafirmagreg/core/world/new_ow_wg/chunk/TFGChunkNoiseFiller.java
@@ -346,7 +346,9 @@ public class TFGChunkNoiseFiller extends TFGChunkHeightFiller {
 
         final Flow flow = localBiome.hasRivers() ? calculateFlowAt(cellX, cellZ) : Flow.NONE;
 
-        final int maxFilledY = 1 + Math.max(Math.max(heightNoiseValue, seaLevel), beardifierMaxY);
+        final int maxFilledYWithoutBeardifier = 1 + Math.max(heightNoiseValue, seaLevel);
+        final int maxFilledY = Math.max(maxFilledYWithoutBeardifier, beardifierMaxY);
+
         final int maxFilledCellY = Math.min(settings.cellCountY() - 1, 1 + Math.floorDiv(maxFilledY, settings.cellHeight()) - settings.firstCellY());
         final int maxFilledSectionY = Math.min(chunk.getSectionsCount() - 1, 1 + chunk.getSectionIndex(maxFilledY));
 
@@ -380,7 +382,15 @@ public class TFGChunkNoiseFiller extends TFGChunkHeightFiller {
 
                 interpolator.updateForY(cellDeltaY);
 
-                final double noise = calculateNoiseAtHeight(y, heightNoiseValue);
+                double noise = calculateNoiseAtHeight(y, heightNoiseValue);
+
+                // Above the normal fill range, only the beardifier should place blocks,
+                // so we force the terrain noise to be slightly biased towards air at best.
+                // This works around a bug where terrain noise by itself places blocks above
+                // the normal maxFilledY.
+                if (y >= maxFilledYWithoutBeardifier) {
+                    noise = Math.min(noise, -0.05);
+                }
                 final BlockState state = calculateBlockStateAtNoise(y, noise);
                 final FluidState fluid = state.getFluidState();
 


### PR DESCRIPTION
## Bug details
Due to rounding and stuff, the terrain noise can actually be slightly above zero in the block above the surface.

Normally this would cause a block to be placed, but TFC doesn't actually iterate that Y value normally so it gets cut off.

With the beardifier needing to iterate additional Y values, this caused a bunch of additional blocks to be placed on the surface just from the terrain noise, if a structure was nearby.

## Fix details
If we're dealing with a Y value that's above the normal surface height, we clamp the terrain noise value to negative 0.05 ( == slightly biased towards air). That way the beardifier can still pull it up to solid terrain if the structure is nearby enough.