### PR TITLE
Big Barrel Duplication Fix

### DIFF
--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/aeronos.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/aeronos.json
@@ -11,9 +11,19 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/big_barrel/aeronos",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "barrel_part": "0"
+              }
+            }
+          ],
           "name": "tfg:wood/big_barrel/aeronos"
         }
       ],
+      "name": "loot_pool",
       "rolls": 1.0
     }
   ],

--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/ginkgo.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/ginkgo.json
@@ -11,9 +11,19 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/big_barrel/ginkgo",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "barrel_part": "0"
+              }
+            }
+          ],
           "name": "tfg:wood/big_barrel/ginkgo"
         }
       ],
+      "name": "loot_pool",
       "rolls": 1.0
     }
   ],

--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/glacian.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/glacian.json
@@ -11,9 +11,19 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/big_barrel/glacian",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "barrel_part": "0"
+              }
+            }
+          ],
           "name": "tfg:wood/big_barrel/glacian"
         }
       ],
+      "name": "loot_pool",
       "rolls": 1.0
     }
   ],

--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/strophar.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/big_barrel/strophar.json
@@ -11,9 +11,19 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/big_barrel/strophar",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "barrel_part": "0"
+              }
+            }
+          ],
           "name": "tfg:wood/big_barrel/strophar"
         }
       ],
+      "name": "loot_pool",
       "rolls": 1.0
     }
   ],

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
@@ -22,6 +22,7 @@ import net.dries007.tfc.common.items.BarrelBlockItem;
 import net.dries007.tfc.common.items.ChestBlockItem;
 import net.dries007.tfc.util.registry.RegistryWood;
 import net.dries007.tfc.world.feature.tree.TFCTreeGrower;
+import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -32,6 +33,12 @@ import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.predicates.ExplosionCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePropertyCondition;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
 import net.minecraftforge.client.model.generators.BlockModelBuilder;
 import net.minecraftforge.client.model.generators.CustomLoaderBuilder;
 import net.minecraftforge.client.model.generators.ModelFile;
@@ -524,6 +531,16 @@ public class TFGBlocks_Wood {
                 })
                 .item(BlockItem::new).model(ModelUtils.blockItemModel(TFGCore.id("block/wood/big_barrel/" + type.name + "_item")))
                 .build()
+                .loot((lt, block) -> lt.add(block, LootTable.lootTable()
+                        .withPool(LootPool.lootPool()
+                                .name("loot_pool")
+                                .setRolls(ConstantValue.exactly(1))
+                                .add(LootItem.lootTableItem(block)
+                                        .when(LootItemBlockStatePropertyCondition
+                                                .hasBlockStateProperties(block)
+                                                .setProperties(StatePropertiesPredicate.Builder.properties()
+                                                        .hasProperty(FLStateProperties.BARREL_PART, 0))))
+                                .when(ExplosionCondition.survivesExplosion()))))
                 .register();
     }
 


### PR DESCRIPTION
### What is the new behavior?
Datagen now creates a loot table that prevents big barrels from dropping 8 times.

### Implementation Details
- Added a `.loot` to big barrel's datagen.

### Additional Information
- Added this to Core so it could be reused if more new wood blocks will be added.