### PR TITLE
Fix beneath railgun crash

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/InterplanetaryLogisticsNetwork.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/InterplanetaryLogisticsNetwork.java
@@ -53,7 +53,9 @@ public class InterplanetaryLogisticsNetwork extends SavedData {
         var partsTag = tag.getList("networkParts", ListTag.TAG_COMPOUND);
         partsTag.forEach(t -> {
             var part = new NetworkPart((CompoundTag) t);
-            parts.put(part.getPartId(), part);
+            if (DIMENSION_DISTANCES.containsKey(part.getPartId().dimension())) {
+                parts.put(part.getPartId(), part);
+            }
         });
     }
 
@@ -68,6 +70,11 @@ public class InterplanetaryLogisticsNetwork extends SavedData {
     }
 
     public void loadOrCreatePart(ILogisticsNetworkMachine machine) {
+        if (!DIMENSION_DISTANCES.containsKey(machine.getDimensionalPos().dimension())) {
+            TFGCore.LOGGER.warn("Interplanetary logistics machine is in an unsupported dimension. {} {}",
+                    machine.getDimensionalPos(), machine.getMachine());
+            return;
+        }
 
         boolean isReceiver = machine instanceof ILogisticsNetworkReceiver;
 

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryItemLauncherMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryItemLauncherMachine.java
@@ -258,6 +258,8 @@ public class InterplanetaryItemLauncherMachine extends WorkableElectricMultibloc
         var sendPos = InterplanetaryLogisticsNetwork.DIMENSION_DISTANCES.get(getDimensionalPos().dimension());
         var receiverPos = InterplanetaryLogisticsNetwork.DIMENSION_DISTANCES
                 .get(receiver.getDimensionalPos().dimension());
+        if (sendPos == null || receiverPos == null)
+            return false;
         var travelTime = Math.abs(sendPos - receiverPos);
 
         if (!tryExtractFromCircuitInventory(itemsToExtract, config.getSenderDistinctInventory(), true)

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryItemReceiverMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryItemReceiverMachine.java
@@ -23,6 +23,7 @@ import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 
+import su.terrafirmagreg.core.common.tfgt.interdim_logistics.InterplanetaryLogisticsNetwork;
 import su.terrafirmagreg.core.common.tfgt.interdim_logistics.InterplanetaryLogisticsNetwork.*;
 import su.terrafirmagreg.core.common.tfgt.interdim_logistics.NetworkReceiverConfigEntry;
 import su.terrafirmagreg.core.common.tfgt.machine.multiblock.part.RailgunItemBusMachine;
@@ -59,7 +60,7 @@ public class InterplanetaryItemReceiverMachine extends WorkableElectricMultibloc
     @Override
     public void onLoad() {
         super.onLoad();
-        if (getLevel() instanceof ServerLevel sLvl)
+        if (getLevel() instanceof ServerLevel sLvl && InterplanetaryLogisticsNetwork.DIMENSION_DISTANCES.containsKey(getDimensionalPos().dimension()))
             sLvl.getServer().tell(new TickTask(0, () -> getLogisticsNetwork().loadOrCreatePart(this)));
     }
 


### PR DESCRIPTION
Bit of code to fix a null pointer crash when a railgun receiver is built in the beneath or other unregistered dimensions.

The idea is that these dimensions shouldn't even show up the in the monitor. If they still happen to show up and set as a destination, then at least they'll just silently fail.

[crash-2026-04-18_01.34.39-server.txt](https://github.com/user-attachments/files/26845003/crash-2026-04-18_01.34.39-server.txt)
