### PR TITLE
Allow railguns to send to receivers in the same dimension

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryItemLauncherMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryItemLauncherMachine.java
@@ -189,8 +189,6 @@ public class InterplanetaryItemLauncherMachine extends WorkableElectricMultibloc
     private boolean tryLaunchItemPayload(NetworkSenderConfigEntry config) {
         if (energyInputs == null || !isFormed || !isWorkingEnabled())
             return false;
-        if (config.getReceiverPartID().dimension().equals(config.getSenderPartID().dimension()))
-            return false;
         var destination = getLogisticsNetwork().getNetworkMachine(config.getReceiverPartID());
         if (!(destination instanceof ILogisticsNetworkReceiver receiver))
             return false;

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryLogisticsMonitorMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/interdim_logistics/machine/InterplanetaryLogisticsMonitorMachine.java
@@ -188,7 +188,7 @@ public class InterplanetaryLogisticsMonitorMachine extends MetaMachine implement
                     .setButtonBackground(GuiTextures.BUTTON);
             if (!isRemote())
                 destinationSelector.setCandidatesSupplier(() -> uiParts.stream()
-                        .filter((p) -> p.isReceiverPart() && !Objects.equals(p.getUiLabel(), "[unnamed]") && !p.getPartId().dimension().equals(part.getPartId().dimension()))
+                        .filter((p) -> p.isReceiverPart() && !Objects.equals(p.getUiLabel(), "[unnamed]"))
                         .map(NetworkPart::getUiLabel).toList());
             destinationSelector.setValue("[none]");
             DimensionalBlockPos receiver = config.getReceiverPartID();


### PR DESCRIPTION
Reverts 0f34a5ae0e1b847dffcec0dc1da097dbea3c46d9

transfer is instant (still costs ammo)

Tested sending from overworld to overworld, works fine.