### PR TITLE
rotten ingredient wrapper ignores non-food items

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/IDelegateIngredientAccessor.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/IDelegateIngredientAccessor.java
@@ -1,0 +1,15 @@
+package su.terrafirmagreg.core.mixins.common.tfc;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.dries007.tfc.common.recipes.ingredients.DelegateIngredient;
+import net.minecraft.world.item.crafting.Ingredient;
+
+@Mixin(value = DelegateIngredient.class, remap = false)
+public interface IDelegateIngredientAccessor {
+    @Accessor("delegate")
+    @Nullable
+    Ingredient getDelegate();
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/NotRottenIngredientMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/tfc/NotRottenIngredientMixin.java
@@ -1,0 +1,42 @@
+package su.terrafirmagreg.core.mixins.common.tfc;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.dries007.tfc.common.capabilities.food.FoodCapability;
+import net.dries007.tfc.common.recipes.ingredients.NotRottenIngredient;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+
+/**
+ * Allows non-food items to pass the notRotten check.
+ */
+@Mixin(value = NotRottenIngredient.class, remap = false)
+public class NotRottenIngredientMixin {
+
+    /**
+     * Passes test if the item has no food capability and the delegate ingredient still matches.
+     */
+    @Inject(method = "test(Lnet/minecraft/world/item/ItemStack;)Z", at = @At("RETURN"), cancellable = true)
+    private void tfg$onTest(@Nullable ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+        if (!cir.getReturnValue() && stack != null && !stack.isEmpty() && FoodCapability.get(stack) == null) {
+            Ingredient delegate = ((IDelegateIngredientAccessor) (Object) this).getDelegate();
+            if (delegate == null || delegate.test(stack)) {
+                cir.setReturnValue(true);
+            }
+        }
+    }
+
+    /**
+     * If the item has no food capability, return the stack rather than null.
+     */
+    @Inject(method = "testDefaultItem(Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/world/item/ItemStack;", at = @At("RETURN"), cancellable = true)
+    private void tfg$onTestDefaultItem(ItemStack stack, CallbackInfoReturnable<ItemStack> cir) {
+        if (cir.getReturnValue() == null) {
+            cir.setReturnValue(stack);
+        }
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -197,6 +197,8 @@
         "common.tfc.IIngotPileBlockEntityEntryAccessor",
         "common.tfc.LivestockAiMixin",
         "common.tfc.MoldCapabilityMixin",
+        "common.tfc.IDelegateIngredientAccessor",
+        "common.tfc.NotRottenIngredientMixin",
         "common.tfc.OverworldClimateModelMixin",
         "common.tfc.PotBlockEntityMixin",
         "common.tfc.RammingPreyAiMixin",


### PR DESCRIPTION
If you use a notRotten condition on a non food item the stack just becomes null. Which is annoying. So now it just returns itself.