### PR TITLE
Add a minimum spoilage days field to rotten voiding cover

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/cover/RottenVoidCover.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/cover/RottenVoidCover.java
@@ -1,16 +1,23 @@
 package su.terrafirmagreg.core.common.tfgt.cover;
 
-import org.jetbrains.annotations.NotNull;
-
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.filter.ItemFilter;
+import com.gregtechceu.gtceu.api.gui.GuiTextures;
+import com.gregtechceu.gtceu.api.gui.widget.IntInputWidget;
+import com.gregtechceu.gtceu.api.gui.widget.ToggleButtonWidget;
 import com.gregtechceu.gtceu.common.cover.voiding.ItemVoidingCover;
-import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
+import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
+import com.lowdragmc.lowdraglib.gui.widget.Widget;
+import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 
 import net.dries007.tfc.common.capabilities.food.FoodCapability;
 import net.dries007.tfc.common.capabilities.food.IFood;
+import net.dries007.tfc.util.calendar.Calendars;
+import net.dries007.tfc.util.calendar.ICalendar;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -20,38 +27,88 @@ import net.minecraftforge.items.IItemHandlerModifiable;
  */
 public class RottenVoidCover extends ItemVoidingCover {
 
-    public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(
-            RottenVoidCover.class, ItemVoidingCover.MANAGED_FIELD_HOLDER);
+    protected int minimumDaysRemaining = 0;
 
     public RottenVoidCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide) {
         super(definition, coverHolder, attachedSide);
     }
 
     @Override
-    public @NotNull ManagedFieldHolder getFieldHolder() {
-        return MANAGED_FIELD_HOLDER;
-    }
-
-    @Override
     protected void doVoidItems() {
+        if (!isWorkingEnabled())
+            return;
+
         IItemHandler handler = getOwnItemHandler();
         if (!(handler instanceof IItemHandlerModifiable modifiable))
             return;
 
         ItemFilter filter = filterHandler.getFilter();
+
+        final long now = Calendars.get().getTicks();
+        final long thresholdTicks = (long) minimumDaysRemaining * ICalendar.TICKS_IN_DAY;
+
         for (int slot = 0; slot < handler.getSlots(); slot++) {
             ItemStack sourceStack = handler.getStackInSlot(slot);
             if (sourceStack.isEmpty())
                 continue;
 
             IFood food = FoodCapability.get(sourceStack);
-            if (food == null || !food.isRotten())
+            if (food == null)
                 continue;
 
             if (!filter.test(sourceStack))
                 continue;
 
-            modifiable.setStackInSlot(slot, ItemStack.EMPTY);
+            if (food.isRotten() || food.getRottenDate() - now <= thresholdTicks) {
+                modifiable.setStackInSlot(slot, ItemStack.EMPTY);
+            }
         }
+    }
+
+    @Override
+    public Widget createUIWidget() {
+        WidgetGroup group = new WidgetGroup(0, 0, 176, 140);
+        group.addWidget(new LabelWidget(10, 5, getUITitle()));
+        group.addWidget(new ToggleButtonWidget(
+                10,
+                20,
+                20,
+                20,
+                GuiTextures.BUTTON_POWER,
+                this::isWorkingEnabled,
+                this::setWorkingEnabled));
+        group.addWidget(new LabelWidget(
+                10,
+                45,
+                "tfg.tooltip.cover.rotten_void_days"));
+        group.addWidget(new IntInputWidget(
+                10,
+                58,
+                80,
+                20,
+                () -> minimumDaysRemaining,
+                value -> minimumDaysRemaining = Math.max(0, value))
+                .setMin(0));
+        group.addWidget(filterHandler.createFilterConfigUI(
+                10,
+                82,
+                126,
+                60));
+        group.addWidget(filterHandler.createFilterSlotUI(
+                148,
+                111));
+        return group;
+    }
+
+    @Override
+    public CompoundTag copyConfig(CompoundTag tag) {
+        tag.putInt("minimum_days_remaining", minimumDaysRemaining);
+        return super.copyConfig(tag);
+    }
+
+    @Override
+    public void pasteConfig(ServerPlayer player, CompoundTag tag) {
+        minimumDaysRemaining = Math.max(0, tag.getInt("minimum_days_remaining"));
+        super.pasteConfig(player, tag);
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/cover/RottenVoidCover.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/cover/RottenVoidCover.java
@@ -80,7 +80,7 @@ public class RottenVoidCover extends ItemVoidingCover {
         group.addWidget(new LabelWidget(
                 10,
                 45,
-                "tfg.tooltip.cover.rotten_void_days"));
+                "tfg.gui.cover.rotten_void_days"));
         group.addWidget(new IntInputWidget(
                 10,
                 58,


### PR DESCRIPTION
when updating, minimum days get set to zero (i.e. only void rotten stuff)

<img width="1920" height="1032" alt="Screenshot 2026-05-14 205037" src="https://github.com/user-attachments/assets/574f0af1-d0d3-4031-b8f4-2c85499d69e3" />

gtm8 is taking longer than expected...