### PR TITLE
Fix firmalife dupe with mechanical crafter

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/create/RecipeGridHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/create/RecipeGridHandlerMixin.java
@@ -1,0 +1,22 @@
+package su.terrafirmagreg.core.mixins.common.create;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.simibubi.create.content.kinetics.crafter.RecipeGridHandler;
+
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+
+@Mixin(value = RecipeGridHandler.class, remap = false)
+public class RecipeGridHandlerMixin {
+    @Inject(method = "isRecipeAllowed", at = @At("HEAD"), cancellable = true)
+    private static void tfg$blockTFCFoodCombining(CraftingRecipe recipe, CraftingContainer inventory, CallbackInfoReturnable<Boolean> cir) {
+        // Fixes dupe caused by creating stacks bigger than the max
+        if (recipe.getId() != null && recipe.getId().toString().equals("tfc:food_combining")) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -51,6 +51,7 @@
         "common.create.DepotBehaviorMixin",
         "common.create.OpenEndedPipeMixin",
         "common.create.ProcessingRecipeMixin",
+        "common.create.RecipeGridHandlerMixin",
         "common.create.SuperGlueHandlerMixin",
         "common.create.chains.ChainConveyorBlockEntityMixin",
         "common.create.chains.ChainConveyorBlockMixin",


### PR DESCRIPTION
Followup to https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/4038 that also fixes duping any #tfc:foods including meal bags (trivial integer limit aluminium dust)