### PR TITLE
Disables Concrete Speed Boost and FOV

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/client/gtceu/GTForgeClientEventListenerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/gtceu/GTForgeClientEventListenerMixin.java
@@ -1,0 +1,18 @@
+package su.terrafirmagreg.core.mixins.client.gtceu;
+
+import com.gregtechceu.gtceu.client.forge.ForgeClientEventListener;
+import net.minecraftforge.client.event.ComputeFovModifierEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(value = ForgeClientEventListener.class, remap = false)
+public class GTForgeClientEventListenerMixin {
+    /**
+     * @author Sakura
+     * @reason Disables that damn FOV change when walking on blocks so we can reuse tags in block runner.
+     */
+    @Overwrite
+    @SubscribeEvent
+    public static void updateFOV(ComputeFovModifierEvent event) { }
+}

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTForgeCommonEventListenerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/GTForgeCommonEventListenerMixin.java
@@ -1,0 +1,21 @@
+package su.terrafirmagreg.core.mixins.common.gtceu;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import com.gregtechceu.gtceu.forge.ForgeCommonEventListener;
+
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+@Mixin(value = ForgeCommonEventListener.class, remap = false)
+public class GTForgeCommonEventListenerMixin {
+    /**
+     * @author Sakura
+     * @reason Messes with block runner for some unknown reason.
+     */
+    @Overwrite
+    @SubscribeEvent
+    public static void playerTickEvent(TickEvent.PlayerTickEvent event) {
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -266,7 +266,9 @@
         "common.wab.SoarerMixin",
         "common.wab.SoarerOverlayMixin",
         "common.wab.ToxlacanthMixin",
-        "common.tfc.TFCFoxMixin"
+        "common.tfc.TFCFoxMixin",
+        "common.gtceu.GTForgeCommonEventListenerMixin",
+        "client.gtceu.GTForgeClientEventListenerMixin"
     ],
     "minVersion": "0.8",
     "package": "su.terrafirmagreg.core.mixins",


### PR DESCRIPTION

### What is the new behavior?
Disables GTCEu's Concrete Block speed boost and fov change. Will add block runner on Modpack's side.