### PR TITLE
Add dynamic map color for asphalt road

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadHelper.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadHelper.java
@@ -9,9 +9,11 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.material.MapColor;
 
 public final class AsphaltRoadHelper {
 
@@ -37,6 +39,16 @@ public final class AsphaltRoadHelper {
     public static final EnumProperty<DyeColor> COLOR = EnumProperty.create("color", DyeColor.class);
 
     private AsphaltRoadHelper() {
+    }
+
+    /**
+     * Map color: black when unmarked, dye color when a marking mask is set.
+     */
+    public static MapColor getMapColor(BlockState state) {
+        if (state.hasProperty(MASK) && state.hasProperty(COLOR) && !state.getValue(MASK).isNone()) {
+            return state.getValue(COLOR).getMapColor();
+        }
+        return MapColor.COLOR_BLACK;
     }
 
     /**

--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadHelper.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadHelper.java
@@ -24,7 +24,6 @@ public final class AsphaltRoadHelper {
     public static final long HEAT_DAMAGE_INTERVAL_TICKS = 20L;
     public static final int HOT_CONTACT_MAX_DAMAGE = 1;
     public static final float HOT_CONTACT_DAMAGE_MULTIPLIER = 1.0F;
-    public static final float HOT_ITEM_DAMAGE = 1.0F;
 
     public static final int POURING_SPREAD_MAX_BLOCKS = 20;
     public static final int POURING_SPREAD_BATCH_PER_TICK = 1;

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocksAsphalt.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocksAsphalt.java
@@ -61,7 +61,7 @@ public final class TFGBlocksAsphalt {
 
     public static final BlockEntry<AsphaltRoadBlock> ASPHALT_ROAD = TFGCore.REGISTRATE.block("asphalt_road", AsphaltRoadBlock::new)
             .initialProperties(() -> Blocks.BLACK_CONCRETE)
-            .properties(p -> p.strength(5F, 64).sound(SoundType.STONE).mapColor(MapColor.COLOR_BLACK).requiresCorrectToolForDrops())
+            .properties(p -> p.strength(5F, 64).sound(SoundType.STONE).mapColor(AsphaltRoadHelper::getMapColor).requiresCorrectToolForDrops())
             .addLayer(() -> RenderType::cutout)
             .blockstate(TFGBlocksAsphalt::asphaltRoadBlockstate)
             .loot(RegistrateBlockLootTables::dropSelf)
@@ -81,7 +81,7 @@ public final class TFGBlocksAsphalt {
 
     public static final BlockEntry<AsphaltRoadSlabBlock> ASPHALT_ROAD_SLAB = TFGCore.REGISTRATE.block("asphalt_road_slab", AsphaltRoadSlabBlock::new)
             .initialProperties(ASPHALT_ROAD)
-            .properties(BlockBehaviour.Properties::requiresCorrectToolForDrops)
+            .properties(p -> p.mapColor(AsphaltRoadHelper::getMapColor).requiresCorrectToolForDrops())
             .addLayer(() -> RenderType::cutout)
             .blockstate(TFGBlocksAsphalt::asphaltRoadSlabBlockstate)
             .loot(RegistrateBlockLootTables::dropSelf)


### PR DESCRIPTION
## What is the new behavior?
You can see your paintings on the Xaero's map, but only works when `Block Colours` set to `Vanilla` mode.
Wont work in `Accurate` mode.