### PR TITLE
Fix ad astra lander mounting not working because the chunk was presumably not loaded

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/ModUtilsMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/ModUtilsMixin.java
@@ -8,10 +8,13 @@ import java.util.Objects;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.TicketType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.phys.Vec3;
 
 import earth.terrarium.adastra.common.container.VehicleContainer;
@@ -29,6 +32,10 @@ public class ModUtilsMixin {
      */
     @Overwrite
     public static void land(ServerPlayer pilotPlayer, ServerLevel targetLevel, Vec3 pos) {
+        BlockPos landingPos = BlockPos.containing(pos);
+        targetLevel.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(landingPos), 1, landingPos);
+        targetLevel.getChunk(landingPos);
+
         Entity vehicle = pilotPlayer.getVehicle();
 
         if (vehicle instanceof Rocket rocket) {


### PR DESCRIPTION
Addresses https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3054

From what was shared about the issue and from what I've seen in the logs, this seems to be caused by failing to mount the Ad Astra lander because the chunk wasn't loaded. Due to the nature of this bug, I have no way to verify that this fix works.
