### PR TITLE
Custom loot table conditions

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/CommonProxy.java
+++ b/src/main/java/su/terrafirmagreg/core/common/CommonProxy.java
@@ -71,6 +71,7 @@ public class CommonProxy {
         TFGEvents.register();
         TFGSounds.SOUNDS.register(bus);
         TFGCarvers.CARVERS.register(bus);
+        TFGLootConditions.LOOT_CONDITIONS.register(bus);
 
         TFGBrain.MEMORY_TYPES.register(bus);
         TFGBrain.SENSOR_TYPES.register(bus);

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGLootConditions.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGLootConditions.java
@@ -1,0 +1,40 @@
+package su.terrafirmagreg.core.common.data;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+import su.terrafirmagreg.core.TFGCore;
+import su.terrafirmagreg.core.common.loot.conditions.AverageRainfallLootCondition;
+import su.terrafirmagreg.core.common.loot.conditions.AverageTemperatureLootCondition;
+import su.terrafirmagreg.core.common.loot.conditions.GravityLootCondition;
+import su.terrafirmagreg.core.common.loot.conditions.MonthLootCondition;
+import su.terrafirmagreg.core.common.loot.conditions.OxygenatedLootCondition;
+import su.terrafirmagreg.core.common.loot.conditions.SeasonLootCondition;
+
+/**
+ * Registry for custom loot conditions used in TFG.
+ */
+public class TFGLootConditions {
+
+    public static final DeferredRegister<LootItemConditionType> LOOT_CONDITIONS = DeferredRegister.create(Registries.LOOT_CONDITION_TYPE, TFGCore.MOD_ID);
+
+    public static final RegistryObject<LootItemConditionType> OXYGENATED_LOOT_CONDITION = LOOT_CONDITIONS.register("oxygenated",
+            () -> new LootItemConditionType(new OxygenatedLootCondition.ConditionSerializer()));
+
+    public static final RegistryObject<LootItemConditionType> MONTH_LOOT_CONDITION = LOOT_CONDITIONS.register("months",
+            () -> new LootItemConditionType(new MonthLootCondition.ConditionSerializer()));
+
+    public static final RegistryObject<LootItemConditionType> SEASON_LOOT_CONDITION = LOOT_CONDITIONS.register("seasons",
+            () -> new LootItemConditionType(new SeasonLootCondition.ConditionSerializer()));
+
+    public static final RegistryObject<LootItemConditionType> AVERAGE_TEMPERATURE_LOOT_CONDITION = LOOT_CONDITIONS.register("climate_avg_temperature",
+            () -> new LootItemConditionType(new AverageTemperatureLootCondition.ConditionSerializer()));
+
+    public static final RegistryObject<LootItemConditionType> AVERAGE_RAINFALL_LOOT_CONDITION = LOOT_CONDITIONS.register("climate_avg_rainfall",
+            () -> new LootItemConditionType(new AverageRainfallLootCondition.ConditionSerializer()));
+
+    public static final RegistryObject<LootItemConditionType> GRAVITY_LOOT_CONDITION = LOOT_CONDITIONS.register("gravity",
+            () -> new LootItemConditionType(new GravityLootCondition.ConditionSerializer()));
+}

--- a/src/main/java/su/terrafirmagreg/core/common/loot/conditions/AverageRainfallLootCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/loot/conditions/AverageRainfallLootCondition.java
@@ -1,0 +1,123 @@
+package su.terrafirmagreg.core.common.loot.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.dries007.tfc.util.climate.Climate;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraft.world.phys.Vec3;
+
+import su.terrafirmagreg.core.common.data.TFGLootConditions;
+
+/**
+ * Loot condition that checks if the current average rainfall matches.
+ */
+public class AverageRainfallLootCondition implements LootItemCondition {
+
+    public enum Mode {
+        GT,
+        LT,
+        BETWEEN
+    }
+
+    private final boolean isReverse;
+    private final Mode mode;
+    private final float value;
+    private final boolean valuePresent;
+    private final float start;
+    private final boolean startPresent;
+    private final float end;
+    private final boolean endPresent;
+
+    public AverageRainfallLootCondition(boolean isReverse, Mode mode, float value, boolean valuePresent, float start, boolean startPresent, float end, boolean endPresent) {
+        this.isReverse = isReverse;
+        this.mode = mode;
+        this.value = value;
+        this.valuePresent = valuePresent;
+        this.start = start;
+        this.startPresent = startPresent;
+        this.end = end;
+        this.endPresent = endPresent;
+    }
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TFGLootConditions.AVERAGE_RAINFALL_LOOT_CONDITION.get();
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        var level = context.getLevel();
+        BlockPos pos = getPos(context);
+        float climate = Climate.getRainfall(level, pos);
+
+        boolean passes;
+        switch (mode) {
+            case GT -> passes = valuePresent && climate > value;
+            case LT -> passes = valuePresent && climate < value;
+            case BETWEEN -> {
+                if (startPresent && endPresent) {
+                    float s = Math.min(start, end);
+                    float e = Math.max(start, end);
+                    passes = climate > s && climate < e;
+                } else {
+                    passes = false;
+                }
+            }
+            default -> passes = false;
+        }
+        return isReverse != passes;
+    }
+
+    private BlockPos getPos(LootContext context) {
+        Vec3 origin = context.getParamOrNull(LootContextParams.ORIGIN);
+        if (origin != null) {
+            return BlockPos.containing(origin);
+        }
+        Entity entity = context.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (entity != null) {
+            return entity.blockPosition();
+        }
+        return BlockPos.ZERO;
+    }
+
+    public static class ConditionSerializer implements Serializer<AverageRainfallLootCondition> {
+        @Override
+        public void serialize(@NotNull JsonObject json, @NotNull AverageRainfallLootCondition instance, @NotNull JsonSerializationContext ctx) {
+            json.addProperty("isReverse", instance.isReverse);
+            json.addProperty("mode", instance.mode.name());
+            if (instance.valuePresent) {
+                json.addProperty("value", instance.value);
+            }
+            if (instance.startPresent) {
+                json.addProperty("start", instance.start);
+            }
+            if (instance.endPresent) {
+                json.addProperty("end", instance.end);
+            }
+        }
+
+        @Override
+        public @NotNull AverageRainfallLootCondition deserialize(@NotNull JsonObject json, @NotNull JsonDeserializationContext ctx) {
+            boolean isReverse = GsonHelper.getAsBoolean(json, "isReverse", false);
+            Mode mode = Mode.valueOf(GsonHelper.getAsString(json, "mode", Mode.BETWEEN.name()));
+            boolean valuePresent = json.has("value");
+            float value = valuePresent ? GsonHelper.getAsFloat(json, "value") : 0f;
+            boolean startPresent = json.has("start");
+            float start = startPresent ? GsonHelper.getAsFloat(json, "start") : 0f;
+            boolean endPresent = json.has("end");
+            float end = endPresent ? GsonHelper.getAsFloat(json, "end") : 0f;
+            return new AverageRainfallLootCondition(isReverse, mode, value, valuePresent, start, startPresent, end, endPresent);
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/loot/conditions/AverageTemperatureLootCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/loot/conditions/AverageTemperatureLootCondition.java
@@ -1,0 +1,123 @@
+package su.terrafirmagreg.core.common.loot.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.dries007.tfc.util.climate.Climate;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraft.world.phys.Vec3;
+
+import su.terrafirmagreg.core.common.data.TFGLootConditions;
+
+/**
+ * Loot condition that checks if the current average temp matches.
+ */
+public class AverageTemperatureLootCondition implements LootItemCondition {
+
+    public enum Mode {
+        GT,
+        LT,
+        BETWEEN
+    }
+
+    private final boolean isReverse;
+    private final Mode mode;
+    private final float value;
+    private final boolean valuePresent;
+    private final float start;
+    private final boolean startPresent;
+    private final float end;
+    private final boolean endPresent;
+
+    public AverageTemperatureLootCondition(boolean isReverse, Mode mode, float value, boolean valuePresent, float start, boolean startPresent, float end, boolean endPresent) {
+        this.isReverse = isReverse;
+        this.mode = mode;
+        this.value = value;
+        this.valuePresent = valuePresent;
+        this.start = start;
+        this.startPresent = startPresent;
+        this.end = end;
+        this.endPresent = endPresent;
+    }
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TFGLootConditions.AVERAGE_TEMPERATURE_LOOT_CONDITION.get();
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        var level = context.getLevel();
+        BlockPos pos = getPos(context);
+        float climate = Climate.getAverageTemperature(level, pos);
+
+        boolean passes;
+        switch (mode) {
+            case GT -> passes = valuePresent && climate > value;
+            case LT -> passes = valuePresent && climate < value;
+            case BETWEEN -> {
+                if (startPresent && endPresent) {
+                    float s = Math.min(start, end);
+                    float e = Math.max(start, end);
+                    passes = climate > s && climate < e;
+                } else {
+                    passes = false;
+                }
+            }
+            default -> passes = false;
+        }
+        return isReverse != passes;
+    }
+
+    private BlockPos getPos(LootContext context) {
+        Vec3 origin = context.getParamOrNull(LootContextParams.ORIGIN);
+        if (origin != null) {
+            return BlockPos.containing(origin);
+        }
+        Entity entity = context.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (entity != null) {
+            return entity.blockPosition();
+        }
+        return BlockPos.ZERO;
+    }
+
+    public static class ConditionSerializer implements Serializer<AverageTemperatureLootCondition> {
+        @Override
+        public void serialize(@NotNull JsonObject json, @NotNull AverageTemperatureLootCondition instance, @NotNull JsonSerializationContext ctx) {
+            json.addProperty("isReverse", instance.isReverse);
+            json.addProperty("mode", instance.mode.name());
+            if (instance.valuePresent) {
+                json.addProperty("value", instance.value);
+            }
+            if (instance.startPresent) {
+                json.addProperty("start", instance.start);
+            }
+            if (instance.endPresent) {
+                json.addProperty("end", instance.end);
+            }
+        }
+
+        @Override
+        public @NotNull AverageTemperatureLootCondition deserialize(@NotNull JsonObject json, @NotNull JsonDeserializationContext ctx) {
+            boolean isReverse = GsonHelper.getAsBoolean(json, "isReverse", false);
+            Mode mode = Mode.valueOf(GsonHelper.getAsString(json, "mode", Mode.BETWEEN.name()));
+            boolean valuePresent = json.has("value");
+            float value = valuePresent ? GsonHelper.getAsFloat(json, "value") : 0f;
+            boolean startPresent = json.has("start");
+            float start = startPresent ? GsonHelper.getAsFloat(json, "start") : 0f;
+            boolean endPresent = json.has("end");
+            float end = endPresent ? GsonHelper.getAsFloat(json, "end") : 0f;
+            return new AverageTemperatureLootCondition(isReverse, mode, value, valuePresent, start, startPresent, end, endPresent);
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/loot/conditions/GravityLootCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/loot/conditions/GravityLootCondition.java
@@ -1,0 +1,148 @@
+package su.terrafirmagreg.core.common.loot.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraft.world.phys.Vec3;
+
+import earth.terrarium.adastra.api.systems.GravityApi;
+import earth.terrarium.adastra.common.constants.PlanetConstants;
+
+import su.terrafirmagreg.core.common.data.TFGLootConditions;
+
+/**
+ * Loot condition that checks if the current gravity matches.
+ */
+public class GravityLootCondition implements LootItemCondition {
+
+    private static final float EARTH_GRAVITY = PlanetConstants.EARTH_GRAVITY;
+
+    public enum Mode {
+        GT,
+        LT,
+        BETWEEN
+    }
+
+    private final boolean isReverse;
+    private final Mode mode;
+    private final float value;
+    private final boolean valuePresent;
+    private final float start;
+    private final boolean startPresent;
+    private final float end;
+    private final boolean endPresent;
+
+    public GravityLootCondition(boolean isReverse, Mode mode, float value, boolean valuePresent, float start, boolean startPresent, float end, boolean endPresent) {
+        this.isReverse = isReverse;
+        this.mode = mode;
+        this.value = value;
+        this.valuePresent = valuePresent;
+        this.start = start;
+        this.startPresent = startPresent;
+        this.end = end;
+        this.endPresent = endPresent;
+    }
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TFGLootConditions.GRAVITY_LOOT_CONDITION.get();
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        var level = context.getLevel();
+        BlockPos pos = getPos(context);
+        float gravityRatio = GravityApi.API.getGravity(level, pos);
+
+        boolean passes = isPasses(gravityRatio);
+        return isReverse != passes;
+    }
+
+    private boolean isPasses(float gravityRatio) {
+        boolean passes;
+        switch (mode) {
+            case GT -> {
+                if (!valuePresent) {
+                    passes = false;
+                } else {
+                    float valueRatio = value / EARTH_GRAVITY;
+                    passes = gravityRatio > valueRatio;
+                }
+            }
+            case LT -> {
+                if (!valuePresent) {
+                    passes = false;
+                } else {
+                    float valueRatio = value / EARTH_GRAVITY;
+                    passes = gravityRatio < valueRatio;
+                }
+            }
+            case BETWEEN -> {
+                if (startPresent && endPresent) {
+                    float s = Math.min(start, end);
+                    float e = Math.max(start, end);
+                    float sRatio = s / EARTH_GRAVITY;
+                    float eRatio = e / EARTH_GRAVITY;
+                    passes = gravityRatio > sRatio && gravityRatio < eRatio;
+                } else {
+                    passes = false;
+                }
+            }
+            default -> passes = false;
+        }
+        return passes;
+    }
+
+    private BlockPos getPos(LootContext context) {
+        Vec3 origin = context.getParamOrNull(LootContextParams.ORIGIN);
+        if (origin != null) {
+            return BlockPos.containing(origin);
+        }
+        Entity entity = context.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (entity != null) {
+            return entity.blockPosition();
+        }
+        return BlockPos.ZERO;
+    }
+
+    public static class ConditionSerializer implements Serializer<GravityLootCondition> {
+        @Override
+        public void serialize(@NotNull JsonObject json, @NotNull GravityLootCondition instance, @NotNull JsonSerializationContext ctx) {
+            json.addProperty("isReverse", instance.isReverse);
+            json.addProperty("mode", instance.mode.name());
+            if (instance.valuePresent) {
+                json.addProperty("value", instance.value);
+            }
+            if (instance.startPresent) {
+                json.addProperty("start", instance.start);
+            }
+            if (instance.endPresent) {
+                json.addProperty("end", instance.end);
+            }
+        }
+
+        @Override
+        public @NotNull GravityLootCondition deserialize(@NotNull JsonObject json, @NotNull JsonDeserializationContext ctx) {
+            boolean isReverse = GsonHelper.getAsBoolean(json, "isReverse", false);
+            Mode mode = Mode.valueOf(GsonHelper.getAsString(json, "mode", Mode.BETWEEN.name()));
+            boolean valuePresent = json.has("value");
+            float value = valuePresent ? GsonHelper.getAsFloat(json, "value") : 0f;
+            boolean startPresent = json.has("start");
+            float start = startPresent ? GsonHelper.getAsFloat(json, "start") : 0f;
+            boolean endPresent = json.has("end");
+            float end = endPresent ? GsonHelper.getAsFloat(json, "end") : 0f;
+            return new GravityLootCondition(isReverse, mode, value, valuePresent, start, startPresent, end, endPresent);
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/loot/conditions/MonthLootCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/loot/conditions/MonthLootCondition.java
@@ -1,0 +1,128 @@
+package su.terrafirmagreg.core.common.loot.conditions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.dries007.tfc.util.calendar.Calendars;
+import net.dries007.tfc.util.calendar.ICalendar;
+import net.dries007.tfc.util.calendar.Month;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+
+import su.terrafirmagreg.core.common.data.TFGLootConditions;
+
+/**
+ * Loot condition that checks if the current month matches any of the specified months.
+ */
+public class MonthLootCondition implements LootItemCondition {
+
+    private final boolean isReverse;
+    private final List<Month> months;
+    private final @Nullable Month start;
+    private final @Nullable Month end;
+
+    public MonthLootCondition(boolean isReverse, List<Month> months, @Nullable Month start, @Nullable Month end) {
+        this.isReverse = isReverse;
+        this.months = months == null ? List.of() : List.copyOf(months);
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TFGLootConditions.MONTH_LOOT_CONDITION.get();
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        var level = context.getLevel();
+        var calendar = Calendars.get(level);
+        Month current = ICalendar.getMonthOfYear(
+                calendar.getCalendarTicks(),
+                calendar.getCalendarDaysInMonth());
+
+        boolean passes = matches(current);
+        return isReverse != passes;
+    }
+
+    private boolean matches(Month current) {
+        if (!months.isEmpty()) {
+            return months.contains(current);
+        }
+        if (start != null && end != null) {
+            int s = start.ordinal();
+            int e = end.ordinal();
+            int c = current.ordinal();
+            if (s <= e) {
+                return c >= s && c <= e;
+            } else {
+                return c >= s || c <= e;
+            }
+        }
+        return false;
+    }
+
+    public static class ConditionSerializer implements Serializer<MonthLootCondition> {
+        @Override
+        public void serialize(@NotNull JsonObject json, @NotNull MonthLootCondition instance, @NotNull JsonSerializationContext ctx) {
+            json.addProperty("isReverse", instance.isReverse);
+            if (!instance.months.isEmpty()) {
+                JsonArray monthsArray = new JsonArray();
+                for (Month m : instance.months) {
+                    monthsArray.add(m.ordinal());
+                }
+                json.add("months", monthsArray);
+            }
+            if (instance.start != null) {
+                json.addProperty("start", instance.start.ordinal());
+            }
+            if (instance.end != null) {
+                json.addProperty("end", instance.end.ordinal());
+            }
+        }
+
+        @Override
+        public @NotNull MonthLootCondition deserialize(@NotNull JsonObject json, @NotNull JsonDeserializationContext ctx) {
+            boolean isReverse = GsonHelper.getAsBoolean(json, "isReverse", false);
+            List<Month> months = new ArrayList<>();
+            if (json.has("months")) {
+                JsonArray monthsArray = json.getAsJsonArray("months");
+                for (JsonElement e : monthsArray) {
+                    months.add(parseMonth(e));
+                }
+            }
+            Month start = json.has("start") ? parseMonth(json.get("start")) : null;
+            Month end = json.has("end") ? parseMonth(json.get("end")) : null;
+            return new MonthLootCondition(isReverse, months, start, end);
+        }
+
+        private static Month parseMonth(JsonElement e) {
+            if (e.isJsonPrimitive()) {
+                if (e.getAsJsonPrimitive().isNumber()) {
+                    return Month.valueOf(e.getAsInt());
+                } else {
+                    String name = e.getAsString().trim().toUpperCase(Locale.ROOT);
+                    for (Month m : Month.values()) {
+                        if (m.name().equals(name)) {
+                            return m;
+                        }
+                    }
+                }
+            }
+            return Month.JANUARY;
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/loot/conditions/OxygenatedLootCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/loot/conditions/OxygenatedLootCondition.java
@@ -1,0 +1,88 @@
+package su.terrafirmagreg.core.common.loot.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraft.world.phys.Vec3;
+
+import earth.terrarium.adastra.api.systems.OxygenApi;
+
+import su.terrafirmagreg.core.common.data.TFGLootConditions;
+
+/**
+ * Loot condition that checks if the current oxygenated check passes.
+ */
+public class OxygenatedLootCondition implements LootItemCondition {
+
+    private final boolean isReverse;
+    private final boolean isOxygenated;
+
+    public OxygenatedLootCondition(boolean isReverse, boolean isOxygenated) {
+        this.isReverse = isReverse;
+        this.isOxygenated = isOxygenated;
+    }
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TFGLootConditions.OXYGENATED_LOOT_CONDITION.get();
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        var level = context.getLevel();
+        BlockPos pos = getPos(context);
+
+        boolean hasAdjOxygen = hasOxygenOnAnySide(level, pos);
+        boolean passes = isOxygenated == hasAdjOxygen;
+        return isReverse != passes;
+    }
+
+    private BlockPos getPos(LootContext context) {
+        Vec3 origin = context.getParamOrNull(LootContextParams.ORIGIN);
+        if (origin != null) {
+            return BlockPos.containing(origin);
+        }
+        Entity entity = context.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (entity != null) {
+            return entity.blockPosition();
+        }
+        return BlockPos.ZERO;
+    }
+
+    private static boolean hasOxygenOnAnySide(ServerLevel level, BlockPos pos) {
+        for (Direction dir : Direction.values()) {
+            if (OxygenApi.API.hasOxygen(level, pos.relative(dir))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static class ConditionSerializer implements Serializer<OxygenatedLootCondition> {
+        @Override
+        public void serialize(@NotNull JsonObject json, @NotNull OxygenatedLootCondition instance, @NotNull JsonSerializationContext ctx) {
+            json.addProperty("isReverse", instance.isReverse);
+            json.addProperty("isOxygenated", instance.isOxygenated);
+        }
+
+        @Override
+        public @NotNull OxygenatedLootCondition deserialize(@NotNull JsonObject json, @NotNull JsonDeserializationContext ctx) {
+            boolean isReverse = GsonHelper.getAsBoolean(json, "isReverse", false);
+            boolean isOxygenated = GsonHelper.getAsBoolean(json, "isOxygenated", true);
+            return new OxygenatedLootCondition(isReverse, isOxygenated);
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/common/loot/conditions/SeasonLootCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/loot/conditions/SeasonLootCondition.java
@@ -1,0 +1,154 @@
+package su.terrafirmagreg.core.common.loot.conditions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.dries007.tfc.util.calendar.Calendars;
+import net.dries007.tfc.util.calendar.ICalendar;
+import net.dries007.tfc.util.calendar.Month;
+import net.dries007.tfc.util.calendar.Season;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+
+import su.terrafirmagreg.core.common.data.TFGLootConditions;
+
+/**
+ * Loot condition that checks if the current season matches any of the specified seasons.
+ */
+public class SeasonLootCondition implements LootItemCondition {
+
+    private final boolean isReverse;
+    private final List<Season> seasons;
+    private final @Nullable Season start;
+    private final @Nullable Season end;
+
+    public SeasonLootCondition(boolean isReverse, List<Season> seasons, @Nullable Season start, @Nullable Season end) {
+        this.isReverse = isReverse;
+        this.seasons = seasons == null ? List.of() : List.copyOf(seasons);
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public @NotNull LootItemConditionType getType() {
+        return TFGLootConditions.SEASON_LOOT_CONDITION.get();
+    }
+
+    @Override
+    public boolean test(LootContext context) {
+        var level = context.getLevel();
+        var calendar = Calendars.get(level);
+        Month currentMonth = ICalendar.getMonthOfYear(
+                calendar.getCalendarTicks(),
+                calendar.getCalendarDaysInMonth());
+        Season current = fromMonth(currentMonth);
+
+        boolean passes = matches(current);
+        return isReverse != passes;
+    }
+
+    private boolean matches(Season current) {
+        if (!seasons.isEmpty()) {
+            return seasons.contains(current);
+        }
+        if (start != null && end != null) {
+            int s = start.ordinal();
+            int e = end.ordinal();
+            int c = current.ordinal();
+            if (s <= e) {
+                return c >= s && c <= e;
+            } else {
+                return c >= s || c <= e;
+            }
+        }
+        return false;
+    }
+
+    private static Season fromMonth(Month m) {
+        switch (m) {
+            case DECEMBER, JANUARY, FEBRUARY -> {
+                return Season.WINTER;
+            }
+            case MARCH, APRIL, MAY -> {
+                return Season.SPRING;
+            }
+            case JUNE, JULY, AUGUST -> {
+                return Season.SUMMER;
+            }
+            case SEPTEMBER, OCTOBER, NOVEMBER -> {
+                return Season.FALL;
+            }
+        }
+        return Season.SPRING;
+    }
+
+    public static class ConditionSerializer implements Serializer<SeasonLootCondition> {
+        @Override
+        public void serialize(@NotNull JsonObject json, @NotNull SeasonLootCondition instance, @NotNull JsonSerializationContext ctx) {
+            json.addProperty("isReverse", instance.isReverse);
+            if (!instance.seasons.isEmpty()) {
+                JsonArray seasonsArray = new JsonArray();
+                for (Season s : instance.seasons) {
+                    seasonsArray.add(s.ordinal());
+                }
+                json.add("seasons", seasonsArray);
+            }
+            if (instance.start != null) {
+                json.addProperty("start", instance.start.ordinal());
+            }
+            if (instance.end != null) {
+                json.addProperty("end", instance.end.ordinal());
+            }
+        }
+
+        @Override
+        public @NotNull SeasonLootCondition deserialize(@NotNull JsonObject json, @NotNull JsonDeserializationContext ctx) {
+            boolean isReverse = GsonHelper.getAsBoolean(json, "isReverse", false);
+            List<Season> seasons = new ArrayList<>();
+            if (json.has("seasons")) {
+                JsonArray seasonsArray = json.getAsJsonArray("seasons");
+                for (JsonElement e : seasonsArray) {
+                    seasons.add(parseSeason(e));
+                }
+            }
+            Season start = json.has("start") ? parseSeason(json.get("start")) : null;
+            Season end = json.has("end") ? parseSeason(json.get("end")) : null;
+            return new SeasonLootCondition(isReverse, seasons, start, end);
+        }
+
+        private static Season parseSeason(JsonElement e) {
+            if (e.isJsonPrimitive()) {
+                if (e.getAsJsonPrimitive().isNumber()) {
+                    int ordinal = e.getAsInt();
+                    if (ordinal >= 0 && ordinal < Season.values().length) {
+                        return Season.values()[ordinal];
+                    }
+                } else {
+                    String name = e.getAsString().trim().toUpperCase(Locale.ROOT);
+                    if (name.equals("AUTUMN")) {
+                        name = "FALL";
+                    }
+                    for (Season s : Season.values()) {
+                        if (s.name().equals(name)) {
+                            return s;
+                        }
+                    }
+                }
+            }
+            return Season.SPRING;
+        }
+    }
+}


### PR DESCRIPTION
Adds custom loot table conditions. These are pretty much a 1 for 1 copy of the GT recipe conditions.
Only ones I extensively tested were season, and month conditions.
Ill write proper docs later.

Heres a few examples of how to use them in jsons:
```json
		{
			"name": "loot_pool",
			"rolls": 1,
			"entries": [
				{
					"type": "minecraft:item",
					"name": "tfc:food/red_apple",
					"conditions": [
						{
							"condition": "tfg:months",
							"start": "april",
							"end": "july"
						},
						{
							"condition": "minecraft:random_chance",
							"chance": 0.5
						},
						{
							"condition": "minecraft:block_state_property",
							"block": "tfg:wood/leaves/araucaria",
							"properties": {
								"persistent": "false"
							}
						}
					]
				}
			]
        },
```
> Condition checks for the month range between april and july. It can use month strings or the integer place. 

```json
		{
			"name": "loot_pool",
			"rolls": 1,
			"entries": [
				{
					"type": "minecraft:item",
					"name": "tfc:food/red_apple",
					"conditions": [
						{
							"condition": "tfg:months",
							"months": [
							     "april",
							     "0"
							 ]
						},
						{
							"condition": "minecraft:random_chance",
							"chance": 0.5
						},
						{
							"condition": "minecraft:block_state_property",
							"block": "tfg:wood/leaves/araucaria",
							"properties": {
								"persistent": "false"
							}
						}
					]
				}
			]
        },
```
> Condition checks for either april (string) or january (int).

```json
		{
			"name": "loot_pool",
			"rolls": 1,
			"entries": [
				{
					"type": "minecraft:item",
					"name": "tfc:food/red_apple",
					"conditions": [
						{
							"condition": "tfg:seasons",
							"seasons": [
							     "winter"
							 ]
						},
						{
							"condition": "minecraft:random_chance",
							"chance": 0.5
						},
						{
							"condition": "minecraft:block_state_property",
							"block": "tfg:wood/leaves/araucaria",
							"properties": {
								"persistent": "false"
							}
						}
					]
				}
			]
        },
```
> Condition checks for winter (string) season.