### PR TITLE
Added mars creatures to the pastoral_engine recipes

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/entity/TFGWoolEggProducingAnimal.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/TFGWoolEggProducingAnimal.java
@@ -26,19 +26,19 @@ public abstract class TFGWoolEggProducingAnimal extends ProducingAnimal {
         super(type, level, sounds, config);
     }
 
-    protected abstract Item getWoolItemType();
+    public abstract Item getWoolItemType();
 
-    protected abstract int getMaxWool();
+    public abstract int getMaxWool();
 
     public ItemStack getWoolItem() {
         final int amount = (int) Math.ceil(getFamiliarity() * getMaxWool());
         return new ItemStack(getWoolItemType(), amount);
     }
 
-    protected abstract int getWoolProduceTicks();
+    public abstract int getWoolProduceTicks();
 
     public boolean hasWool() {
-        long cooldown = getWoolCooldown(getWoolProduceTicks());
+        long cooldown = getWoolCooldown();
         if (cooldown == 0) {
             return true;
         } else {
@@ -77,12 +77,12 @@ public abstract class TFGWoolEggProducingAnimal extends ProducingAnimal {
         setWoolProducedTick(Calendars.get(level()).getTicks());
     }
 
-    public long getWoolCooldown(int woolProduceTicks) {
+    public long getWoolCooldown() {
         return Math.max(0, getWoolProduceTicks() + getWoolProducedTick() - Calendars.get(level()).getTicks());
     }
 
-    public boolean hasWoolProduct(int woolProduceTicks) {
-        return (getWoolProducedTick() <= 0 || getWoolCooldown(woolProduceTicks) <= 0) && getAgeType() == Age.ADULT;
+    public boolean hasWoolProduct() {
+        return (getWoolProducedTick() <= 0 || getWoolCooldown() <= 0) && getAgeType() == Age.ADULT;
     }
 
     public MutableComponent getWoolReadyName() {

--- a/src/main/java/su/terrafirmagreg/core/common/entity/TFGWoolEggProducingAnimal.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/TFGWoolEggProducingAnimal.java
@@ -26,13 +26,19 @@ public abstract class TFGWoolEggProducingAnimal extends ProducingAnimal {
         super(type, level, sounds, config);
     }
 
-    public ItemStack getWoolItem(Item woolItem, int maxWool) {
-        final int amount = (int) Math.ceil(getFamiliarity() * maxWool);
-        return new ItemStack(woolItem, amount);
+    protected abstract Item getWoolItemType();
+
+    protected abstract int getMaxWool();
+
+    public ItemStack getWoolItem() {
+        final int amount = (int) Math.ceil(getFamiliarity() * getMaxWool());
+        return new ItemStack(getWoolItemType(), amount);
     }
 
-    public boolean hasWool(int woolProduceTicks) {
-        long cooldown = getWoolCooldown(woolProduceTicks);
+    protected abstract int getWoolProduceTicks();
+
+    public boolean hasWool() {
+        long cooldown = getWoolCooldown(getWoolProduceTicks());
         if (cooldown == 0) {
             return true;
         } else {
@@ -72,7 +78,7 @@ public abstract class TFGWoolEggProducingAnimal extends ProducingAnimal {
     }
 
     public long getWoolCooldown(int woolProduceTicks) {
-        return Math.max(0, woolProduceTicks + getWoolProducedTick() - Calendars.get(level()).getTicks());
+        return Math.max(0, getWoolProduceTicks() + getWoolProducedTick() - Calendars.get(level()).getTicks());
     }
 
     public boolean hasWoolProduct(int woolProduceTicks) {

--- a/src/main/java/su/terrafirmagreg/core/common/entity/sniffer/TFCSniffer.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/sniffer/TFCSniffer.java
@@ -131,17 +131,17 @@ public class TFCSniffer extends TFGWoolEggProducingAnimal implements IForgeShear
     }
 
     @Override
-    protected Item getWoolItemType() {
+    public Item getWoolItemType() {
         return woolItem;
     }
 
     @Override
-    protected int getMaxWool() {
+    public int getMaxWool() {
         return maxWool;
     }
 
     @Override
-    protected int getWoolProduceTicks() {
+    public int getWoolProduceTicks() {
         return woolProduceTicks;
     }
 
@@ -221,12 +221,12 @@ public class TFCSniffer extends TFGWoolEggProducingAnimal implements IForgeShear
     }
 
     public boolean hasWool() {
-        long cooldown = getWoolCooldown(getWoolProduceTicks());
+        long cooldown = getWoolCooldown();
         return cooldown == 0;
     }
 
     public boolean isReadyForWoolProduct() {
-        return getFamiliarity() > produceFamiliarity && hasWoolProduct(getWoolProduceTicks());
+        return getFamiliarity() > produceFamiliarity && hasWoolProduct();
     }
 
     // Sound Handlers

--- a/src/main/java/su/terrafirmagreg/core/common/entity/sniffer/TFCSniffer.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/sniffer/TFCSniffer.java
@@ -130,6 +130,21 @@ public class TFCSniffer extends TFGWoolEggProducingAnimal implements IForgeShear
                 && (getGender() == Gender.FEMALE || (getGender() == Gender.MALE && isFertilized()));
     }
 
+    @Override
+    protected Item getWoolItemType() {
+        return woolItem;
+    }
+
+    @Override
+    protected int getMaxWool() {
+        return maxWool;
+    }
+
+    @Override
+    protected int getWoolProduceTicks() {
+        return woolProduceTicks;
+    }
+
     // Egg Stuff
     @Override
     public AgeableMob getBreedOffspring(@NotNull ServerLevel level, @NotNull AgeableMob other) {
@@ -197,7 +212,7 @@ public class TFCSniffer extends TFGWoolEggProducingAnimal implements IForgeShear
         playSound(SoundEvents.SHEEP_SHEAR, 1.0f, 1.0f);
 
         // if the event was not cancelled
-        AnimalProductEvent event = new AnimalProductEvent(level, pos, player, this, getWoolItem(woolItem, maxWool),
+        AnimalProductEvent event = new AnimalProductEvent(level, pos, player, this, getWoolItem(),
                 item, 1);
         if (!MinecraftForge.EVENT_BUS.post(event)) {
             addUses(event.getUses());
@@ -206,12 +221,12 @@ public class TFCSniffer extends TFGWoolEggProducingAnimal implements IForgeShear
     }
 
     public boolean hasWool() {
-        long cooldown = getWoolCooldown(woolProduceTicks);
+        long cooldown = getWoolCooldown(getWoolProduceTicks());
         return cooldown == 0;
     }
 
     public boolean isReadyForWoolProduct() {
-        return getFamiliarity() > produceFamiliarity && hasWoolProduct(woolProduceTicks);
+        return getFamiliarity() > produceFamiliarity && hasWoolProduct(getWoolProduceTicks());
     }
 
     // Sound Handlers

--- a/src/main/java/su/terrafirmagreg/core/common/entity/wraptor/TFCWraptor.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/wraptor/TFCWraptor.java
@@ -161,17 +161,17 @@ public class TFCWraptor extends TFGWoolEggProducingAnimal implements IForgeShear
     }
 
     @Override
-    protected Item getWoolItemType() {
+    public Item getWoolItemType() {
         return woolItem;
     }
 
     @Override
-    protected int getMaxWool() {
+    public int getMaxWool() {
         return maxWool;
     }
 
     @Override
-    protected int getWoolProduceTicks() {
+    public int getWoolProduceTicks() {
         return woolProduceTicks;
     }
 
@@ -272,11 +272,11 @@ public class TFCWraptor extends TFGWoolEggProducingAnimal implements IForgeShear
 
     public int getFeatherStage() {
         int usesLeft = getUsesToElderly();
-        return hasWoolProduct(woolProduceTicks) ? 6 * (usesLeft / uses) : 0;
+        return hasWoolProduct() ? 6 * (usesLeft / uses) : 0;
     }
 
     public boolean isReadyForWoolProduct() {
-        return getFamiliarity() > produceFamiliarity && hasWoolProduct(woolProduceTicks);
+        return getFamiliarity() > produceFamiliarity && hasWoolProduct();
     }
 
     // AI Handlers

--- a/src/main/java/su/terrafirmagreg/core/common/entity/wraptor/TFCWraptor.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/wraptor/TFCWraptor.java
@@ -160,6 +160,21 @@ public class TFCWraptor extends TFGWoolEggProducingAnimal implements IForgeShear
         return TFGTags.Items.MartianHerbivoreFoods;
     }
 
+    @Override
+    protected Item getWoolItemType() {
+        return woolItem;
+    }
+
+    @Override
+    protected int getMaxWool() {
+        return maxWool;
+    }
+
+    @Override
+    protected int getWoolProduceTicks() {
+        return woolProduceTicks;
+    }
+
     // Sound Handlers
     protected SoundEvent getAmbientSound() {
         return SpeciesSoundEvents.WRAPTOR_IDLE.get();
@@ -248,7 +263,7 @@ public class TFCWraptor extends TFGWoolEggProducingAnimal implements IForgeShear
         playSound(SoundEvents.SHEEP_SHEAR, 1.0f, 1.0f);
 
         // if the event was not cancelled
-        AnimalProductEvent event = new AnimalProductEvent(level, pos, player, this, getWoolItem(woolItem, maxWool), item, 1);
+        AnimalProductEvent event = new AnimalProductEvent(level, pos, player, this, getWoolItem(), item, 1);
         if (!MinecraftForge.EVENT_BUS.post(event)) {
             addUses(event.getUses());
         }

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
@@ -246,10 +246,8 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
 
                 allAnimals.stream()
                         .filter(e -> {
-                            if (!(e instanceof TFCAnimalProperties animal)) {
-                                return false;
-                            }
-                            if (animal.getAgeType() != TFCAnimalProperties.Age.ADULT) {
+                            if (!(e instanceof TFCAnimalProperties animal) ||
+                                    animal.getAgeType() != TFCAnimalProperties.Age.ADULT) {
                                 return false;
                             }
                             if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {
@@ -263,10 +261,21 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
                         .collect(java.util.stream.Collectors.groupingBy(
                                 e -> ForgeRegistries.ENTITY_TYPES.getKey(e.getType()),
                                 java.util.stream.Collectors.minBy(
-                                        java.util.Comparator.comparingLong(
-                                                e -> ((TFCAnimalProperties) e).getProductsCooldown()))))
+                                        java.util.Comparator.comparingLong(e -> {
+                                            if (e instanceof TFGWoolEggProducingAnimal woolAnimal) {
+                                                return woolAnimal.getWoolCooldown();
+                                            }
+                                            return ((TFCAnimalProperties) e).getProductsCooldown();
+                                        }))))
                         .forEach((entityTypeId, optAnimal) -> optAnimal.ifPresent(e -> {
-                            long minCooldown = ((TFCAnimalProperties) e).getProductsCooldown();
+
+                            long minCooldown;
+                            if (e instanceof TFGWoolEggProducingAnimal woolAnimal) {
+                                minCooldown = woolAnimal.getWoolCooldown();
+                            } else {
+                                minCooldown = ((TFCAnimalProperties) e).getProductsCooldown();
+                            }
+
                             long totalHours = minCooldown / ICalendar.TICKS_IN_HOUR;
                             long days = totalHours / ICalendar.HOURS_IN_DAY;
                             long hours = totalHours % ICalendar.HOURS_IN_DAY;

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
@@ -241,14 +241,11 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
                 allAnimals.stream()
                         .filter(e -> {
                             if (!(e instanceof TFCAnimalProperties animal) ||
-                                    animal.getAgeType() != TFCAnimalProperties.Age.ADULT) {
-                                return false;
-                            }
-                            if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {
-                                return !woolAnimal.hasWool();
-                            }
-                            if (animal instanceof ProducingMammal producer) {
-                                return !animal.isReadyForAnimalProduct() && producer.getProducedTick() > 0;
+                                    (animal.getAgeType() == TFCAnimalProperties.Age.ADULT) ||
+                                    (animal instanceof TFGWoolEggProducingAnimal woolAnimal) && (!woolAnimal.hasWool()) ||
+                                    (animal instanceof ProducingMammal producer) &&
+                                            !(animal.isReadyForAnimalProduct() || producer.getProducedTick() > 0)) {
+                                return true;
                             }
                             return false;
                         })

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
@@ -29,6 +29,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import su.terrafirmagreg.core.common.entity.TFGWoolEggProducingAnimal;
 import su.terrafirmagreg.core.common.tfgt.recipe.condition.AnimalPresentCondition;
 
 public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
@@ -80,12 +81,23 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
         final AnimalPresentCondition finalCondition = condition;
 
         List<Entity> ready = serverLevel.getEntities(
-                (Entity) null, getFormedBoundingBox(),
-                entity -> entity instanceof TFCAnimalProperties animal
-                        && animal.isReadyForAnimalProduct()
-                        && animal.getAgeType() != TFCAnimalProperties.Age.OLD // Not old so can still produce
-                        // Filter from condition
-                        && (finalCondition == null || finalCondition.matchesEntity(entity)));
+                (Entity) null,
+                getFormedBoundingBox(),
+                entity -> {
+                    if (!(entity instanceof TFCAnimalProperties animal))
+                        return false;
+
+                    if (animal.getAgeType() == TFCAnimalProperties.Age.OLD)
+                        return false;
+
+                    if (finalCondition != null && !finalCondition.matchesEntity(entity))
+                        return false;
+
+                    if (animal instanceof TFGWoolEggProducingAnimal woolAnimal)
+                        return woolAnimal.hasWool();
+
+                    return animal.isReadyForAnimalProduct();
+                });
 
         for (Entity entity : ready) {
             if (!(entity instanceof TFCAnimalProperties animal))
@@ -93,7 +105,13 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
 
             AnimalProductEvent event = buildEvent(serverLevel, animal);
             if (!MinecraftForge.EVENT_BUS.post(event)) {
-                animal.setProductsCooldown(); // Animals products put on cooldown
+                // Animals products put on cooldown
+                if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {
+                    woolAnimal.setWoolCooldown();
+                } else {
+                    animal.setProductsCooldown();
+                }
+
                 /*
                 TFGCore.LOGGER.info("[Pastoral] Cooldown appliqué sur {} — cooldown restant: {}",
                         animal.getEntity().getType().getDescriptionId(),
@@ -125,6 +143,13 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
                     wooly.getWoolItem(),
                     ItemStack.EMPTY, 1);
         }
+        if (animal instanceof TFGWoolEggProducingAnimal woollyeggy) {
+            return new AnimalProductEvent(
+                    level, woollyeggy.blockPosition(), null, woollyeggy,
+                    woollyeggy.getWoolItem(),
+                    ItemStack.EMPTY, 1);
+        }
+
         // Fallback for the other ProducingAnimal
         return new AnimalProductEvent(
                 level, animal.getEntity().blockPosition(), null, animal,
@@ -182,6 +207,10 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
                 if (e instanceof TFCAnimalProperties animal) {
                     if (animal.getAgeType() == TFCAnimalProperties.Age.OLD) {
                         old++;
+                    } else if (animal instanceof TFGWoolEggProducingAnimal wooly) {
+                        if (wooly.hasWool()) {
+                            ready++;
+                        }
                     } else if (animal.isReadyForAnimalProduct()) {
                         ready++;
                     }
@@ -197,22 +226,40 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
 
             // Cooldown par type
             boolean hasAnimalOnCooldown = allAnimals.stream()
-                    .anyMatch(e -> e instanceof TFCAnimalProperties animal
-                            && animal.getAgeType() != TFCAnimalProperties.Age.OLD
-                            && !animal.isReadyForAnimalProduct());
+                    .anyMatch(e -> {
+                        if (!(e instanceof TFCAnimalProperties animal)) {
+                            return false;
+                        }
+                        if (animal.getAgeType() == TFCAnimalProperties.Age.OLD) {
+                            return false;
+                        }
+                        if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {
+                            return !woolAnimal.hasWool();
+                        }
+                        return !animal.isReadyForAnimalProduct();
+
+                    });
 
             if (hasAnimalOnCooldown) {
                 textList.add(Component.translatable("tfg.machine.pastoral_engine.next_harvest_title")
                         .withStyle(ChatFormatting.YELLOW));
 
                 allAnimals.stream()
-                        .filter(e -> e instanceof TFCAnimalProperties animal
-                                // Filter so only animals that can produce milk have their cooldown checked
-                                && e instanceof ProducingMammal producer
-                                && animal.getAgeType() == TFCAnimalProperties.Age.ADULT
-                                && animal.getGender() == TFCAnimalProperties.Gender.FEMALE
-                                && !animal.isReadyForAnimalProduct()
-                                && producer.getProducedTick() > 0) // Check that the animal already produced milk at least once
+                        .filter(e -> {
+                            if (!(e instanceof TFCAnimalProperties animal)) {
+                                return false;
+                            }
+                            if (animal.getAgeType() != TFCAnimalProperties.Age.ADULT) {
+                                return false;
+                            }
+                            if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {
+                                return !woolAnimal.hasWool();
+                            }
+                            if (animal instanceof ProducingMammal producer) {
+                                return !animal.isReadyForAnimalProduct() && producer.getProducedTick() > 0;
+                            }
+                            return false;
+                        })
                         .collect(java.util.stream.Collectors.groupingBy(
                                 e -> ForgeRegistries.ENTITY_TYPES.getKey(e.getType()),
                                 java.util.stream.Collectors.minBy(

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/PastoralEngineMachine.java
@@ -84,18 +84,14 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
                 (Entity) null,
                 getFormedBoundingBox(),
                 entity -> {
-                    if (!(entity instanceof TFCAnimalProperties animal))
+                    if (!(entity instanceof TFCAnimalProperties animal) ||
+                            animal.getAgeType() == TFCAnimalProperties.Age.OLD ||
+                            finalCondition != null && !finalCondition.matchesEntity(entity)) {
                         return false;
-
-                    if (animal.getAgeType() == TFCAnimalProperties.Age.OLD)
-                        return false;
-
-                    if (finalCondition != null && !finalCondition.matchesEntity(entity))
-                        return false;
-
-                    if (animal instanceof TFGWoolEggProducingAnimal woolAnimal)
-                        return woolAnimal.hasWool();
-
+                    }
+                    if (animal instanceof TFGWoolEggProducingAnimal woolAnimal && woolAnimal.hasWool()) {
+                        return true;
+                    }
                     return animal.isReadyForAnimalProduct();
                 });
 
@@ -227,10 +223,8 @@ public class PastoralEngineMachine extends WorkableElectricMultiblockMachine {
             // Cooldown par type
             boolean hasAnimalOnCooldown = allAnimals.stream()
                     .anyMatch(e -> {
-                        if (!(e instanceof TFCAnimalProperties animal)) {
-                            return false;
-                        }
-                        if (animal.getAgeType() == TFCAnimalProperties.Age.OLD) {
+                        if (!(e instanceof TFCAnimalProperties animal) ||
+                                animal.getAgeType() == TFCAnimalProperties.Age.OLD) {
                             return false;
                         }
                         if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/recipe/condition/AnimalPresentCondition.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/recipe/condition/AnimalPresentCondition.java
@@ -25,6 +25,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.common.data.tfgt.TFGRecipeConditions;
+import su.terrafirmagreg.core.common.entity.TFGWoolEggProducingAnimal;
 import su.terrafirmagreg.core.common.tfgt.machine.multiblock.electric.PastoralEngineMachine;
 
 public class AnimalPresentCondition extends RecipeCondition<AnimalPresentCondition> {
@@ -117,12 +118,22 @@ public class AnimalPresentCondition extends RecipeCondition<AnimalPresentConditi
         AABB box = getSearchBox(machine);
 
         return !level.getEntities((Entity) null, box, entity -> {
-            if (!(entity instanceof TFCAnimalProperties animal))
+            if (entity instanceof TFGWoolEggProducingAnimal animal) {
+                if (animal.getAgeType() == TFCAnimalProperties.Age.OLD)
+                    return false;
+                if (animalType.equals("producing") && !animal.hasWool())
+                    return false;
+                // In case we have a machine in the future that wants eggs
+                if (animalType.equals("dairy") && !animal.isReadyForAnimalProduct())
+                    return false;
+            } else if (entity instanceof TFCAnimalProperties animal) {
+                if (animal.getAgeType() == TFCAnimalProperties.Age.OLD)
+                    return false;
+                if (!animal.isReadyForAnimalProduct())
+                    return false;
+            } else {
                 return false;
-            if (animal.getAgeType() == TFCAnimalProperties.Age.OLD)
-                return false;
-            if (!animal.isReadyForAnimalProduct())
-                return false;
+            }
 
             // Filter through entity type if defined
             if (entityTypeId != null) {
@@ -153,8 +164,17 @@ public class AnimalPresentCondition extends RecipeCondition<AnimalPresentConditi
             return false;
         if (animal.getAgeType() == TFCAnimalProperties.Age.OLD)
             return false;
-        if (!animal.isReadyForAnimalProduct())
-            return false;
+
+        if (animal instanceof TFGWoolEggProducingAnimal woolAnimal) {
+            if (animalType.equals("producing") && !woolAnimal.hasWool())
+                return false;
+            // In case we have a machine in the future that wants eggs 
+            if (animalType.equals("dairy") && !woolAnimal.isReadyForAnimalProduct())
+                return false;
+        } else {
+            if (!animal.isReadyForAnimalProduct())
+                return false;
+        }
 
         // Filter per entity type if specified
         if (entityTypeId != null) {


### PR DESCRIPTION
## What is the new behavior?
Changes to the core mod needed for [#4125](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/4125) in Modpack-Modern. 
Includes some additional logic for GT machines to work with `WoolEggProducingAnimals` like Wraptors and Sniffers. These are a custom mobtype created by TerraFirmaGreg.


## Implementation Details
Because of the way that WoolEggProducingAnimals were implemented, the PastoralEngineMachine  would update WoolEggProducingAnimals with the method `.setProductsCooldown()`, but this points to the cooldown for eggs on these animals and not the wool product. Instead, I have had it update `.setWoolCooldown()` on WoolEggProducingAnimals like Wraptors and Sniffers.

`AnimalPresentCondition.java` was not setup to access the wool cooldown on these animals as well, and without adding a check using WoolEggProducingAnimals `hasWool()` method, the machine would infinitely produce Wraptor and Sniffer's shear products if the animal had eggs. 

## Outcome
- Added logic surrounding WoolEggProducingAnimals to `PastoralEngineMachine.java`
- Added logic surrounding WoolEggProducingAnimals to `AnimalPresentCondition.java` so any future machines can just use kube.js hooks to access both products of animals.

## Additional Information
To see the recipes appear ingame, this PR is dependent upon [#4125](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/4125)