### PR TITLE
Some namespace changes

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ClientProxy.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ClientProxy.java
@@ -30,7 +30,7 @@ import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.client.screen.*;
 import su.terrafirmagreg.core.common.CommonProxy;
 import su.terrafirmagreg.core.common.data.*;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.blocks.*;
 import su.terrafirmagreg.core.common.particle.*;
 import su.terrafirmagreg.core.common.tfgt.machine.render.BouleRender;

--- a/src/main/java/su/terrafirmagreg/core/client/MobColorItemClientHandler.java
+++ b/src/main/java/su/terrafirmagreg/core/client/MobColorItemClientHandler.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.TFGCore;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 //import su.terrafirmagreg.core.compat.starcatcher.StarcatcherFishVariants;
 
 @SuppressWarnings("deprecation")

--- a/src/main/java/su/terrafirmagreg/core/client/asphalt/AsphaltRoadColorHandlers.java
+++ b/src/main/java/su/terrafirmagreg/core/client/asphalt/AsphaltRoadColorHandlers.java
@@ -10,7 +10,7 @@ import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadHelper;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadMarkingMask;
-import su.terrafirmagreg.core.common.data.blocks.TFGBlocksAsphalt;
+import su.terrafirmagreg.core.common.data.blocks.TFGBlocks_Asphalt;
 
 @OnlyIn(Dist.CLIENT)
 public final class AsphaltRoadColorHandlers {
@@ -32,16 +32,16 @@ public final class AsphaltRoadColorHandlers {
         };
 
         event.register(asphaltDecalColor,
-                TFGBlocksAsphalt.ASPHALT_ROAD.get(),
-                TFGBlocksAsphalt.ASPHALT_ROAD_SLAB.get());
+                TFGBlocks_Asphalt.ASPHALT_ROAD.get(),
+                TFGBlocks_Asphalt.ASPHALT_ROAD_SLAB.get());
     }
 
     public static void registerItems(RegisterColorHandlersEvent.Item event) {
         final ItemColor asphaltLineColor = (stack, tintIndex) -> tintIndex == 1 ? DyeColor.WHITE.getTextColor() : -1;
 
         event.register(asphaltLineColor,
-                TFGBlocksAsphalt.ASPHALT_ROAD.get().asItem(),
-                TFGBlocksAsphalt.ASPHALT_ROAD_SLAB.get().asItem());
+                TFGBlocks_Asphalt.ASPHALT_ROAD.get().asItem(),
+                TFGBlocks_Asphalt.ASPHALT_ROAD_SLAB.get().asItem());
     }
 
     private static AsphaltMarking getAsphaltMarking(BlockState state) {

--- a/src/main/java/su/terrafirmagreg/core/client/wearable/TFGWearableEquipmentLayer.java
+++ b/src/main/java/su/terrafirmagreg/core/client/wearable/TFGWearableEquipmentLayer.java
@@ -21,7 +21,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
 import su.terrafirmagreg.core.TFGCore;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 
 /**
  * Renders entity models for snorkel / flippers / snowshoes in armor slots.

--- a/src/main/java/su/terrafirmagreg/core/client/wearable/TFGWearableRenderSetup.java
+++ b/src/main/java/su/terrafirmagreg/core/client/wearable/TFGWearableRenderSetup.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import top.theillusivec4.curios.api.client.CuriosRendererRegistry;
 
 import su.terrafirmagreg.core.TFGCore;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public final class TFGWearableRenderSetup {

--- a/src/main/java/su/terrafirmagreg/core/common/CommonProxy.java
+++ b/src/main/java/su/terrafirmagreg/core/common/CommonProxy.java
@@ -22,7 +22,7 @@ import de.mari_023.ae2wtlib.AE2wtlib;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.data.*;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.blocks.TFGBlocks;
 import su.terrafirmagreg.core.common.data.tfgt.TFGMachines;
 import su.terrafirmagreg.core.common.data.tfgt.TFGMultiMachines;

--- a/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
@@ -40,7 +40,7 @@ import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.capability.LargeEggCapability;
 import su.terrafirmagreg.core.common.capability.LargeEggHandler;
 import su.terrafirmagreg.core.common.data.TFGCommands;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.tfgt.TFGMultiMachines;
 import su.terrafirmagreg.core.common.perf.SupportCache;
 import su.terrafirmagreg.core.network.TFGNetworkHandler;

--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadHotBlock.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadHotBlock.java
@@ -12,7 +12,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
-import su.terrafirmagreg.core.common.data.blocks.TFGBlocksAsphalt;
+import su.terrafirmagreg.core.common.data.blocks.TFGBlocks_Asphalt;
 
 @SuppressWarnings("deprecation")
 public class AsphaltRoadHotBlock extends Block {
@@ -51,8 +51,8 @@ public class AsphaltRoadHotBlock extends Block {
     @Override
     public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
         super.tick(state, level, pos, random);
-        level.setBlock(pos, TFGBlocksAsphalt.ASPHALT_ROAD.getDefaultState(), Block.UPDATE_ALL);
-        level.updateNeighborsAt(pos, TFGBlocksAsphalt.ASPHALT_ROAD.get());
+        level.setBlock(pos, TFGBlocks_Asphalt.ASPHALT_ROAD.getDefaultState(), Block.UPDATE_ALL);
+        level.updateNeighborsAt(pos, TFGBlocks_Asphalt.ASPHALT_ROAD.get());
     }
 
     @Override

--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/blockentity/AsphaltPouringSpreadBlockEntity.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/blockentity/AsphaltPouringSpreadBlockEntity.java
@@ -18,7 +18,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadHelper;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadPouringBlock;
-import su.terrafirmagreg.core.common.data.blocks.TFGBlocksAsphalt;
+import su.terrafirmagreg.core.common.data.blocks.TFGBlocks_Asphalt;
 
 public class AsphaltPouringSpreadBlockEntity extends BlockEntity {
 
@@ -44,8 +44,8 @@ public class AsphaltPouringSpreadBlockEntity extends BlockEntity {
             BlockPos baseNeighbor = BlockPos.of(spreadPlan[spreadIndex++]);
             BlockState baseState = level.getBlockState(baseNeighbor);
             if (baseState.is(RNRTags.Blocks.CONCRETE_SPREADABLE)) {
-                level.setBlock(baseNeighbor, TFGBlocksAsphalt.ASPHALT_ROAD_HOT.getDefaultState(), Block.UPDATE_ALL);
-                level.updateNeighborsAt(baseNeighbor, TFGBlocksAsphalt.ASPHALT_ROAD_HOT.get());
+                level.setBlock(baseNeighbor, TFGBlocks_Asphalt.ASPHALT_ROAD_HOT.getDefaultState(), Block.UPDATE_ALL);
+                level.updateNeighborsAt(baseNeighbor, TFGBlocks_Asphalt.ASPHALT_ROAD_HOT.get());
             }
             processed++;
         }

--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/event/AsphaltRoadPourEvent.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/event/AsphaltRoadPourEvent.java
@@ -29,7 +29,7 @@ import net.minecraftforge.fml.common.Mod;
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadHelper;
 import su.terrafirmagreg.core.common.data.TFGFluids;
-import su.terrafirmagreg.core.common.data.blocks.TFGBlocksAsphalt;
+import su.terrafirmagreg.core.common.data.blocks.TFGBlocks_Asphalt;
 
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID)
 public final class AsphaltRoadPourEvent {
@@ -117,7 +117,7 @@ public final class AsphaltRoadPourEvent {
         if (!space.isAir() && !space.canBeReplaced()) {
             return;
         }
-        BlockState pourState = TFGBlocksAsphalt.ASPHALT_ROAD_POURING.getDefaultState();
+        BlockState pourState = TFGBlocks_Asphalt.ASPHALT_ROAD_POURING.getDefaultState();
         if (!level.setBlock(pourPos, pourState, Block.UPDATE_ALL)) {
             return;
         }
@@ -138,7 +138,7 @@ public final class AsphaltRoadPourEvent {
         if (!player.getAbilities().instabuild && !canAffordFluidDrain(held, AsphaltRoadHelper.PATCH_POUR_MB)) {
             return;
         }
-        if (!level.setBlock(clicked, TFGBlocksAsphalt.ASPHALT_ROAD_HOT.getDefaultState(), Block.UPDATE_ALL)) {
+        if (!level.setBlock(clicked, TFGBlocks_Asphalt.ASPHALT_ROAD_HOT.getDefaultState(), Block.UPDATE_ALL)) {
             return;
         }
         if (!player.getAbilities().instabuild && !tryConsumeFluidMb(player, hand, held, AsphaltRoadHelper.PATCH_POUR_MB)) {

--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/event/AsphaltRoadSprayEvent.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/event/AsphaltRoadSprayEvent.java
@@ -32,7 +32,7 @@ import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadBlock;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadHelper;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadMarkingMask;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadSlabBlock;
-import su.terrafirmagreg.core.common.data.TFGItemsAsphalt;
+import su.terrafirmagreg.core.common.data.items.TFGItems_Asphalt;
 import su.terrafirmagreg.core.common.data.TFGTags;
 
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID)
@@ -200,7 +200,7 @@ public final class AsphaltRoadSprayEvent {
 
         if (sprayHand == InteractionHand.MAIN_HAND) {
             if (opposite.is(TFGTags.Items.ROAD_MARKING_STENCILS)) {
-                return TFGItemsAsphalt.maskForStencil(opposite).orElse(null);
+                return TFGItems_Asphalt.maskForStencil(opposite).orElse(null);
             }
             return AsphaltRoadMarkingMask.LINE;
         }
@@ -211,7 +211,7 @@ public final class AsphaltRoadSprayEvent {
         if (!opposite.is(TFGTags.Items.ROAD_MARKING_STENCILS)) {
             return null;
         }
-        return TFGItemsAsphalt.maskForStencil(opposite).orElse(null);
+        return TFGItems_Asphalt.maskForStencil(opposite).orElse(null);
     }
 
     @Nullable

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGBlockEntities.java
@@ -57,7 +57,7 @@ public class TFGBlockEntities {
 
     public static final BlockEntityEntry<AsphaltPouringSpreadBlockEntity> ASPHALT_POURING_SPREAD = TFGCore.REGISTRATE
             .blockEntity("asphalt_pouring_spread", AsphaltPouringSpreadBlockEntity::new)
-            .validBlock(TFGBlocksAsphalt.ASPHALT_ROAD_POURING)
+            .validBlock(TFGBlocks_Asphalt.ASPHALT_ROAD_POURING)
             .register();
 
     public static final BlockEntityEntry<TickerBlockEntity> TICKER_ENTITY = TFGCore.REGISTRATE.blockEntity("particle_emitter", TickerBlockEntity::new)

--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGFluids.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGFluids.java
@@ -29,6 +29,8 @@ import net.minecraftforge.registries.DeferredRegister;
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadHelper;
 import su.terrafirmagreg.core.common.data.blocks.TFGBlocks;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems_Asphalt;
 
 public class TFGFluids {
 
@@ -110,7 +112,7 @@ public class TFGFluids {
     public static final FluidRegistryObject<ForgeFlowingFluid> ASPHALT_MIX = register(
             "asphalt_mix",
             properties -> properties
-                    .bucket(TFGItemsAsphalt.ASPHALT_MIX_BUCKET),
+                    .bucket(TFGItems_Asphalt.ASPHALT_MIX_BUCKET),
             FluidType.Properties.create()
                     .adjacentPathType(BlockPathTypes.LAVA)
                     .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks.java
@@ -53,7 +53,7 @@ public final class TFGBlocks {
         TFGBlocks_Casings.init();
         TFGBlocks_Buds.init();
         TFGBlocks_Wood.init();
-        TFGBlocksAsphalt.init();
+        TFGBlocks_Asphalt.init();
         TFGBlocks_Girders.init();
         TFGBlocks_Struts.init();
     }

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Asphalt.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Asphalt.java
@@ -35,7 +35,7 @@ import su.terrafirmagreg.core.common.data.TFGBlockEntities;
 import su.terrafirmagreg.core.utils.ModelUtils;
 
 @SuppressWarnings("unused")
-public final class TFGBlocksAsphalt {
+public final class TFGBlocks_Asphalt {
 
     public static void init() {
     }
@@ -44,7 +44,7 @@ public final class TFGBlocksAsphalt {
             AsphaltRoadPouringBlock::new)
             .initialProperties(() -> Blocks.BLACK_CONCRETE)
             .properties(p -> p.strength(-1.0F, 3600000.0F).sound(SoundType.MUD).mapColor(MapColor.COLOR_BLACK).noLootTable())
-            .blockstate(TFGBlocksAsphalt::asphaltRoadPouringBlockstate)
+            .blockstate(TFGBlocks_Asphalt::asphaltRoadPouringBlockstate)
             .loot((prov, block) -> prov.add(block, LootTable.lootTable()))
             .item(BlockItem::new).model(ModelUtils.blockItemModel(TFGCore.id("block/asphalt_road/pouring_" + AsphaltRoadPouringBlock.MAX_VISUAL_LEVEL))).build()
             .register();
@@ -52,7 +52,7 @@ public final class TFGBlocksAsphalt {
     public static final BlockEntry<AsphaltRoadHotBlock> ASPHALT_ROAD_HOT = TFGCore.REGISTRATE.block("asphalt_road_hot", AsphaltRoadHotBlock::new)
             .initialProperties(() -> Blocks.BLACK_CONCRETE)
             .properties(p -> p.strength(1.5F, 6).sound(SoundType.TUFF).mapColor(MapColor.COLOR_BLACK).requiresCorrectToolForDrops())
-            .blockstate(TFGBlocksAsphalt::asphaltRoadHotBlockstate)
+            .blockstate(TFGBlocks_Asphalt::asphaltRoadHotBlockstate)
             .tag(BlockTags.MINEABLE_WITH_PICKAXE, TFCTags.Blocks.SUPPORTS_LANDSLIDE, TFCTags.Blocks.TOUGHNESS_2)
             .onRegister(block -> TFGBlockEntities.addValidBEBlock(TFCBlockEntities.TICK_COUNTER, block))
             .loot(RegistrateBlockLootTables::dropSelf)
@@ -63,7 +63,7 @@ public final class TFGBlocksAsphalt {
             .initialProperties(() -> Blocks.BLACK_CONCRETE)
             .properties(p -> p.strength(5F, 64).sound(SoundType.STONE).mapColor(AsphaltRoadHelper::getMapColor).requiresCorrectToolForDrops())
             .addLayer(() -> RenderType::cutout)
-            .blockstate(TFGBlocksAsphalt::asphaltRoadBlockstate)
+            .blockstate(TFGBlocks_Asphalt::asphaltRoadBlockstate)
             .loot(RegistrateBlockLootTables::dropSelf)
             .tag(BlockTags.MINEABLE_WITH_PICKAXE, TFCTags.Blocks.SUPPORTS_LANDSLIDE, TFCTags.Blocks.TOUGHNESS_2)
             .item(BlockItem::new).model(ModelUtils.blockItemModel(TFGCore.id("block/asphalt_road/block_base"))).build()
@@ -73,7 +73,7 @@ public final class TFGBlocksAsphalt {
             p -> new AsphaltRoadStairsBlock(() -> ASPHALT_ROAD.get().defaultBlockState(), p))
             .initialProperties(ASPHALT_ROAD)
             .properties(BlockBehaviour.Properties::requiresCorrectToolForDrops)
-            .blockstate(TFGBlocksAsphalt::asphaltRoadStairsBlockstate)
+            .blockstate(TFGBlocks_Asphalt::asphaltRoadStairsBlockstate)
             .loot(RegistrateBlockLootTables::dropSelf)
             .tag(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.STAIRS, TFCTags.Blocks.SUPPORTS_LANDSLIDE, TFCTags.Blocks.TOUGHNESS_2)
             .item(BlockItem::new).model(ModelUtils.blockItemModel(TFGCore.id("block/asphalt_road/stairs"))).build()
@@ -83,7 +83,7 @@ public final class TFGBlocksAsphalt {
             .initialProperties(ASPHALT_ROAD)
             .properties(p -> p.mapColor(AsphaltRoadHelper::getMapColor).requiresCorrectToolForDrops())
             .addLayer(() -> RenderType::cutout)
-            .blockstate(TFGBlocksAsphalt::asphaltRoadSlabBlockstate)
+            .blockstate(TFGBlocks_Asphalt::asphaltRoadSlabBlockstate)
             .loot(RegistrateBlockLootTables::dropSelf)
             .tag(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.SLABS, TFCTags.Blocks.SUPPORTS_LANDSLIDE, TFCTags.Blocks.TOUGHNESS_2)
             .item(BlockItem::new).model(ModelUtils.blockItemModel(TFGCore.id("block/asphalt_road/slab_base"))).build()

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Earth.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Earth.java
@@ -1,6 +1,6 @@
 package su.terrafirmagreg.core.common.data.blocks;
 
-import static su.terrafirmagreg.core.common.data.TFGItems.*;
+import static su.terrafirmagreg.core.common.data.items.TFGItems.*;
 import static su.terrafirmagreg.core.common.data.blocks.TFGBlocks.dropBetween;
 
 import java.util.Locale;
@@ -49,7 +49,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.block.*;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.TFGPlant;
 
 @SuppressWarnings("unused")

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
@@ -19,6 +19,7 @@ import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 
+import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
@@ -174,7 +175,7 @@ public class TFGBlocks_Wood {
                 .blockstate((ctx, prov) -> {
                     prov.axisBlock(ctx.getEntry(), TFGCore.id("block/wood/log/" + wood.serializedName), TFGCore.id("block/wood/log_top/" + wood.serializedName));
                 })
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.withDefaultNamespace("logs")))
+                .tag(BlockTags.LOGS, TFCTags.Blocks.LOGS_THAT_LOG)
                 .tag(TagKey.create(Registries.BLOCK, TFGCore.id(wood.serializedName + "_logs")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .item()
@@ -192,7 +193,7 @@ public class TFGBlocks_Wood {
                 .blockstate((ctx, prov) -> {
                     prov.axisBlock(ctx.getEntry(), TFGCore.id("block/wood/stripped_log/" + wood.serializedName), TFGCore.id("block/wood/stripped_log_top/" + wood.serializedName));
                 })
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.withDefaultNamespace("logs")))
+                .tag(BlockTags.LOGS, TFCTags.Blocks.LOGS_THAT_LOG)
                 .tag(TagKey.create(Registries.BLOCK, TFGCore.id(wood.serializedName + "_logs")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .item()
@@ -211,7 +212,7 @@ public class TFGBlocks_Wood {
                 .blockstate((ctx, prov) -> {
                     prov.axisBlock(ctx.getEntry(), TFGCore.id("block/wood/log/" + wood.serializedName), TFGCore.id("block/wood/log/" + wood.serializedName));
                 })
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.withDefaultNamespace("logs")))
+                .tag(BlockTags.LOGS, TFCTags.Blocks.LOGS_THAT_LOG)
                 .tag(TagKey.create(Registries.BLOCK, TFGCore.id(wood.serializedName + "_logs")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .item()
@@ -228,7 +229,7 @@ public class TFGBlocks_Wood {
                 .blockstate((ctx, prov) -> {
                     prov.axisBlock(ctx.getEntry(), TFGCore.id("block/wood/stripped_log/" + wood.serializedName), TFGCore.id("block/wood/stripped_log/" + wood.serializedName));
                 })
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.withDefaultNamespace("logs")))
+                .tag(BlockTags.LOGS, TFCTags.Blocks.LOGS_THAT_LOG)
                 .tag(TagKey.create(Registries.BLOCK, TFGCore.id(wood.serializedName + "_logs")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .item()

--- a/src/main/java/su/terrafirmagreg/core/common/data/items/TFGItems.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/items/TFGItems.java
@@ -1,4 +1,4 @@
-package su.terrafirmagreg.core.common.data;
+package su.terrafirmagreg.core.common.data.items;
 
 import com.eerussianguy.beneath.common.items.BeneathItemTags;
 import com.gregtechceu.gtceu.api.item.ComponentItem;
@@ -29,6 +29,8 @@ import de.mennomax.astikorcarts.item.CartItem;
 import earth.terrarium.adastra.common.items.vehicles.RocketItem;
 
 import su.terrafirmagreg.core.TFGCore;
+import su.terrafirmagreg.core.common.data.TFGEntities;
+import su.terrafirmagreg.core.common.data.TFGFluids;
 import su.terrafirmagreg.core.common.data.blocks.TFGBlocks;
 import su.terrafirmagreg.core.common.data.tfgt.TFGCovers;
 import su.terrafirmagreg.core.common.item.*;
@@ -40,7 +42,7 @@ import su.terrafirmagreg.core.utils.ModelUtils;
 @SuppressWarnings("unused")
 public class TFGItems {
     public static void init() {
-        TFGItemsAsphalt.init();
+        TFGItems_Asphalt.init();
         TFGItems_Medicines.init();
     }
 

--- a/src/main/java/su/terrafirmagreg/core/common/data/items/TFGItems_Asphalt.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/items/TFGItems_Asphalt.java
@@ -1,4 +1,4 @@
-package su.terrafirmagreg.core.common.data;
+package su.terrafirmagreg.core.common.data.items;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,9 +15,11 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadMarkingMask;
+import su.terrafirmagreg.core.common.data.TFGFluids;
+import su.terrafirmagreg.core.common.data.TFGTags;
 
 @SuppressWarnings("unused")
-public final class TFGItemsAsphalt {
+public final class TFGItems_Asphalt {
 
     private static final Map<ResourceLocation, AsphaltRoadMarkingMask> STENCIL_MASKS = new HashMap<>();
 

--- a/src/main/java/su/terrafirmagreg/core/common/data/items/TFGItems_Medicines.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/items/TFGItems_Medicines.java
@@ -1,6 +1,6 @@
-package su.terrafirmagreg.core.common.data;
+package su.terrafirmagreg.core.common.data.items;
 
-import static su.terrafirmagreg.core.common.data.TFGItems.attach;
+import static su.terrafirmagreg.core.common.data.items.TFGItems.attach;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.item.ComponentItem;

--- a/src/main/java/su/terrafirmagreg/core/common/entity/astikorcarts/RNRPlow.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/astikorcarts/RNRPlow.java
@@ -46,7 +46,7 @@ import de.mennomax.astikorcarts.entity.AbstractDrawnInventoryEntity;
 import de.mennomax.astikorcarts.util.CartItemStackHandler;
 
 import su.terrafirmagreg.core.TFGCore;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 
 /**
  * The RNR Plow entity, an extension of the Astikor Carts mod which

--- a/src/main/java/su/terrafirmagreg/core/common/entity/glacianram/TFCGlacianRam.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/glacianram/TFCGlacianRam.java
@@ -30,7 +30,7 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraftforge.common.IForgeShearable;
 import net.minecraftforge.common.MinecraftForge;
 
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.TFGTags;
 
 public class TFCGlacianRam extends ProducingMammal implements IForgeShearable {

--- a/src/main/java/su/terrafirmagreg/core/common/entity/sniffer/TFCSniffer.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/sniffer/TFCSniffer.java
@@ -42,7 +42,7 @@ import net.minecraftforge.common.MinecraftForge;
 import su.terrafirmagreg.core.common.capability.ILargeEgg;
 import su.terrafirmagreg.core.common.capability.LargeEggCapability;
 import su.terrafirmagreg.core.common.data.TFGEntityDataSerializers;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.TFGTags;
 import su.terrafirmagreg.core.common.entity.TFGWoolEggProducingAnimal;
 

--- a/src/main/java/su/terrafirmagreg/core/common/entity/wraptor/TFCWraptor.java
+++ b/src/main/java/su/terrafirmagreg/core/common/entity/wraptor/TFCWraptor.java
@@ -49,7 +49,7 @@ import net.minecraftforge.common.MinecraftForge;
 
 import su.terrafirmagreg.core.common.capability.ILargeEgg;
 import su.terrafirmagreg.core.common.capability.LargeEggCapability;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.TFGTags;
 import su.terrafirmagreg.core.common.entity.TFGWoolEggProducingAnimal;
 

--- a/src/main/java/su/terrafirmagreg/core/common/event/DnaSyringeEvent.java
+++ b/src/main/java/su/terrafirmagreg/core/common/event/DnaSyringeEvent.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import su.terrafirmagreg.core.TFGCore;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.TFGTags;
 import su.terrafirmagreg.core.config.TFGConfig;
 

--- a/src/main/java/su/terrafirmagreg/core/common/event/WearableAccessoryHandler.java
+++ b/src/main/java/su/terrafirmagreg/core/common/event/WearableAccessoryHandler.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.Mod;
 import top.theillusivec4.curios.api.CuriosApi;
 
 import su.terrafirmagreg.core.TFGCore;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.data.TFGTags;
 import su.terrafirmagreg.core.common.item.wearable.FlippersItem;
 import su.terrafirmagreg.core.common.item.wearable.SnorkelItem;

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/part/RailgunAmmoLoaderMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/part/RailgunAmmoLoaderMachine.java
@@ -7,7 +7,7 @@ import com.gregtechceu.gtceu.api.gui.fancy.ConfiguratorPanel;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 
 public class RailgunAmmoLoaderMachine extends ItemBusPartMachine {
     public RailgunAmmoLoaderMachine(IMachineBlockEntity holder) {

--- a/src/main/java/su/terrafirmagreg/core/mixins/client/minecraft/CustomHeadLayerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/minecraft/CustomHeadLayerMixin.java
@@ -12,7 +12,7 @@ import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 
 /**
  * Vanilla head-item layer draws the snorkel as a flat sprite; we use {@link su.terrafirmagreg.core.client.wearable.TFGWearableEquipmentLayer} instead.

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
@@ -20,7 +20,7 @@ import earth.terrarium.adastra.common.registry.ModEntityTypes;
 import earth.terrarium.adastra.common.tags.ModFluidTags;
 
 import su.terrafirmagreg.core.common.data.TFGEntities;
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.common.entity.rocket.RocketHelper;
 
 @Mixin(value = Rocket.class, remap = false)

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ae2/WirelessTerminalMenuHostMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ae2/WirelessTerminalMenuHostMixin.java
@@ -19,7 +19,7 @@ import appeng.api.networking.IGrid;
 import appeng.blockentity.networking.WirelessAccessPointBlockEntity;
 import appeng.helpers.WirelessTerminalMenuHost;
 
-import su.terrafirmagreg.core.common.data.TFGItems;
+import su.terrafirmagreg.core.common.data.items.TFGItems;
 import su.terrafirmagreg.core.compat.ae2.WirelessCardAccessor;
 import su.terrafirmagreg.core.compat.kjs.events.TFGAE2PowerConsumption;
 


### PR DESCRIPTION
### What is the new behavior?
I wanted to do these changes in my previous strut PR, but separated them out.

### Implementation Details
- `TFGBlocksAsphalt`/`TFGItemsAsphalt` changed to `TFGBlocks_Asphalt`/`TFGItems_Asphalt` to be in line with other file names.
- Created a new `items` package and moved all item classes into it.