### PR TITLE
Allow snow correction to short-circuit when snowAccumulationOnUpdate is set to 0

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/config/ServerConfig.java
+++ b/src/main/java/su/terrafirmagreg/core/config/ServerConfig.java
@@ -11,6 +11,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import earth.terrarium.adastra.api.planets.Planet;
@@ -129,7 +130,7 @@ public final class ServerConfig {
                 .define("enableSnowCorrection", true);
         snowMaxAccumulationOnUpdate = builder
                 .comment("The maximum amount of snow update to apply for each correction tick")
-                .defineInRange("snowMaxAccumulationOnUpdate", 256, 1, Integer.MAX_VALUE);
+                .defineInRange("snowMaxAccumulationOnUpdate", FMLEnvironment.dist.isClient() ? 256 : 0, 0, Integer.MAX_VALUE);
 
         builder.pop().push("tfg_food_effects");
         enableTFGFoodDebuffs = builder

--- a/src/main/java/su/terrafirmagreg/core/utils/SnowCorrection.java
+++ b/src/main/java/su/terrafirmagreg/core/utils/SnowCorrection.java
@@ -61,10 +61,16 @@ public class SnowCorrection {
     private static final int MAX_UPDATES_PER_TICK = TFGConfig.SERVER.snowMaxAccumulationOnUpdate.get();
 
     public static void onTickChunk(ServerLevel level, ChunkAccess chunk) {
+        if (MAX_UPDATES_PER_TICK <= 0) {
+            return;
+        }
+        if (!(chunk instanceof LevelChunk levelChunk)) {
+            return;
+        }
+
         final WorldTracker tracker = WorldTracker.get(level);
         final ClimateModel model = tracker.getClimateModel();
         final ChunkPos chunkPos = chunk.getPos();
-        final LevelChunk levelChunk = level.getChunk(chunkPos.x, chunkPos.z);
         final ChunkData data = ChunkData.get(levelChunk);
         final long currentTick = Calendars.SERVER.getTicks();
         final long currentCalendarTick = Calendars.SERVER.getCalendarTicks();


### PR DESCRIPTION
Addresses a suspicion that the cause of nbt data getting wiped due to ConcurrentModificationException (https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4123) is because of a possibly faulty implementation of snow correction (https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/427)