### PR TITLE
Fix the kinetic bridge exploit

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -168,4 +168,7 @@ dependencies {
 
     // Strut Your Stuff
     modImplementation "maven.modrinth:strut-your-stuff:1.1.0+mc1.20.1"
+
+    // Create: Connected, May 25 2026
+    modImplementation "curse.maven:create-connected-947914:8143922"
 }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/create_connected/KineticBridgeDestinationBlockEntityMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/create_connected/KineticBridgeDestinationBlockEntityMixin.java
@@ -1,0 +1,26 @@
+package su.terrafirmagreg.core.mixins.common.create_connected;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.hlysine.create_connected.content.kineticbridge.KineticBridgeDestinationBlockEntity;
+import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import electrolyte.greate.content.kinetics.simpleRelays.ITieredKineticBlockEntity;
+
+@Mixin(value = KineticBridgeDestinationBlockEntity.class, remap = false)
+public abstract class KineticBridgeDestinationBlockEntityMixin extends GeneratingKineticBlockEntity implements ITieredKineticBlockEntity {
+
+    protected KineticBridgeDestinationBlockEntityMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    @Override
+    public float getMaxCapacityFromBlock(Block block) {
+        return getGeneratedSpeed() * calculateAddedStressCapacity();
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -77,6 +77,7 @@
         "common.create.greate_tiering.WindmillBearingBlockEntityMixin",
         "common.create.greate_tiering.WindmillBearingBlockMixin",
         "common.createliquidfuel.LiquidBurnerFuelJsonLoaderMixin",
+        "common.create_connected.KineticBridgeDestinationBlockEntityMixin",
         "common.emi.ItemEmiStackMixin",
         "common.fallingtrees.StandardTreeMixin",
         "common.firmaciv.BlockEventHandlerMixin",


### PR DESCRIPTION
Makes the kinetic bridge's destination block stress capacity be equal to its generated stress, essentially preventing any other sources from existing on that network. 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c837d8af-7659-4d26-8c16-b174b059d5b8" />
