### PR TITLE
fix: adds missing tags to the new tfg wood chests

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/chests/wooden.json
+++ b/src/generated/resources/data/forge/tags/blocks/chests/wooden.json
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "tfg:wood/trapped_chest/araucaria",
+    "tfg:wood/chest/araucaria",
+    "tfg:wood/trapped_chest/beech",
+    "tfg:wood/chest/beech",
+    "tfg:wood/trapped_chest/mahoe",
+    "tfg:wood/chest/mahoe",
+    "tfg:wood/trapped_chest/glacian",
+    "tfg:wood/chest/glacian",
+    "tfg:wood/trapped_chest/strophar",
+    "tfg:wood/chest/strophar",
+    "tfg:wood/trapped_chest/aeronos",
+    "tfg:wood/chest/aeronos",
+    "tfg:wood/trapped_chest/ginkgo",
+    "tfg:wood/chest/ginkgo"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/chests/wooden.json
+++ b/src/generated/resources/data/forge/tags/items/chests/wooden.json
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "tfg:wood/trapped_chest/araucaria",
+    "tfg:wood/chest/araucaria",
+    "tfg:wood/trapped_chest/beech",
+    "tfg:wood/chest/beech",
+    "tfg:wood/trapped_chest/mahoe",
+    "tfg:wood/chest/mahoe",
+    "tfg:wood/trapped_chest/glacian",
+    "tfg:wood/chest/glacian",
+    "tfg:wood/trapped_chest/strophar",
+    "tfg:wood/chest/strophar",
+    "tfg:wood/trapped_chest/aeronos",
+    "tfg:wood/chest/aeronos",
+    "tfg:wood/trapped_chest/ginkgo",
+    "tfg:wood/chest/ginkgo"
+  ]
+}

--- a/src/generated/resources/data/tfg/tags/items/default_chests.json
+++ b/src/generated/resources/data/tfg/tags/items/default_chests.json
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "tfg:wood/trapped_chest/araucaria",
+    "tfg:wood/chest/araucaria",
+    "tfg:wood/trapped_chest/beech",
+    "tfg:wood/chest/beech",
+    "tfg:wood/trapped_chest/mahoe",
+    "tfg:wood/chest/mahoe",
+    "tfg:wood/trapped_chest/glacian",
+    "tfg:wood/chest/glacian",
+    "tfg:wood/trapped_chest/strophar",
+    "tfg:wood/chest/strophar",
+    "tfg:wood/trapped_chest/aeronos",
+    "tfg:wood/chest/aeronos",
+    "tfg:wood/trapped_chest/ginkgo",
+    "tfg:wood/chest/ginkgo"
+  ]
+}

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
@@ -502,8 +502,8 @@ public class TFGBlocks_Wood {
                     prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(ctx.getName()).texture("particle", wood.plankTexture));
                 })
                 .addLayer(() -> RenderType::cutout)
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
+                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests")),
+                        TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .onRegister(block -> {
                     TFGBlockEntities.addValidBEBlock(TFCBlockEntities.CHEST, block);
@@ -513,9 +513,10 @@ public class TFGBlocks_Wood {
                     prov.withExistingParent(ctx.getName(), ResourceLocation.withDefaultNamespace("item/chest"))
                             .texture("particle", wood.plankTexture);
                 })
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("tfg", "default_chests")))
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests")),
+                        TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")),
+                        TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("tfg", "default_chests")),
+                        TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("firmaciv", "chests")))
                 .build()
                 .register();
     }
@@ -527,8 +528,8 @@ public class TFGBlocks_Wood {
                     prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(ctx.getName()).texture("particle", wood.plankTexture));
                 })
                 .addLayer(() -> RenderType::cutout)
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
-                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
+                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests")),
+                        TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .onRegister(block -> {
                     TFGBlockEntities.addValidBEBlock(TFCBlockEntities.TRAPPED_CHEST, block);
@@ -538,9 +539,10 @@ public class TFGBlocks_Wood {
                     prov.withExistingParent(ctx.getName(), ResourceLocation.withDefaultNamespace("item/chest"))
                             .texture("particle", wood.plankTexture);
                 })
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("tfg", "default_chests")))
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests")),
+                        TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")),
+                        TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("tfg", "default_chests")),
+                        TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("firmaciv", "chests")))
                 .build()
                 .register();
     }

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
@@ -503,6 +503,7 @@ public class TFGBlocks_Wood {
                 })
                 .addLayer(() -> RenderType::cutout)
                 .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
+                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .onRegister(block -> {
                     TFGBlockEntities.addValidBEBlock(TFCBlockEntities.CHEST, block);
@@ -512,7 +513,10 @@ public class TFGBlocks_Wood {
                     prov.withExistingParent(ctx.getName(), ResourceLocation.withDefaultNamespace("item/chest"))
                             .texture("particle", wood.plankTexture);
                 })
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests"))).build()
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("tfg", "default_chests")))
+                .build()
                 .register();
     }
 
@@ -524,6 +528,7 @@ public class TFGBlocks_Wood {
                 })
                 .addLayer(() -> RenderType::cutout)
                 .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
+                .tag(TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
                 .tag(BlockTags.MINEABLE_WITH_AXE)
                 .onRegister(block -> {
                     TFGBlockEntities.addValidBEBlock(TFCBlockEntities.TRAPPED_CHEST, block);
@@ -533,7 +538,10 @@ public class TFGBlocks_Wood {
                     prov.withExistingParent(ctx.getName(), ResourceLocation.withDefaultNamespace("item/chest"))
                             .texture("particle", wood.plankTexture);
                 })
-                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests"))).build()
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests")))
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("forge", "chests/wooden")))
+                .tag(TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("tfg", "default_chests")))
+                .build()
                 .register();
     }
 


### PR DESCRIPTION
## What is the new behavior?
Added the following to tfg's new chests and trapped chests:
- tfg:default_chests (item tag)
- forge:chests/wooden (item tag)
- forge:chests/wooden (block tag)

## Outcome
See TerraFirmaGreg-Team/Modpack-Modern#4260
The new tags are registered in game and the inventory limit (18 items currently) is now shown.

## Additional Information
~~I was unable to add the `alekiships:can_place_in_compartments` and `firmaciv:chests` tags.~~ Tags were added.