### PR TITLE
Make the ad astra rockets launch countdown real-time

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
@@ -10,6 +10,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -31,6 +33,19 @@ public abstract class RocketMixin extends Entity {
 
     @Unique
     private final Rocket tfg$self = (Rocket) (Object) this;
+
+    @Unique
+    private static final long TFG$COUNTDOWN_MS = 5_000L;
+
+    @Unique
+    private long tfg$launchStartMs = -1L;
+
+    @Shadow
+    public abstract int launchTicks();
+
+    @Final
+    @Shadow
+    public static EntityDataAccessor<Integer> LAUNCH_TICKS;
 
     @Mutable
     @Final
@@ -116,6 +131,21 @@ public abstract class RocketMixin extends Entity {
         }
 
         return super.canAddPassenger(pPassenger);
+    }
+
+    @Inject(method = "initiateLaunchSequence", at = @At("RETURN"))
+    private void tfg$recordLaunchStart(CallbackInfo ci) {
+        tfg$launchStartMs = System.currentTimeMillis();
+    }
+
+    @Redirect(method = "tick", remap = true, at = @At(value = "INVOKE", target = "Lnet/minecraft/network/syncher/SynchedEntityData;set(Lnet/minecraft/network/syncher/EntityDataAccessor;Ljava/lang/Object;)V", ordinal = 0))
+    @SuppressWarnings("unchecked")
+    private void tfg$setRealTimeTicks(SynchedEntityData entityData, EntityDataAccessor<?> key, Object value) {
+        if (tfg$launchStartMs < 0L) {
+            entityData.set((EntityDataAccessor<Integer>) key, (Integer) value);
+            return;
+        }
+        entityData.set((EntityDataAccessor<Integer>) key, (int) ((TFG$COUNTDOWN_MS - (System.currentTimeMillis() - tfg$launchStartMs)) / 50L));
     }
 
 }

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/RocketMixin.java
@@ -15,9 +15,11 @@ import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 
 import earth.terrarium.adastra.common.entities.vehicles.Rocket;
+import earth.terrarium.adastra.common.handlers.LaunchingDimensionHandler;
 import earth.terrarium.adastra.common.registry.ModEntityTypes;
 import earth.terrarium.adastra.common.tags.ModFluidTags;
 
@@ -35,10 +37,16 @@ public abstract class RocketMixin extends Entity {
     private final Rocket tfg$self = (Rocket) (Object) this;
 
     @Unique
-    private static final long TFG$COUNTDOWN_MS = 5_000L;
+    private static final long TFG$COUNTDOWN_MS_DEFAULT = 3_000L;
+
+    @Unique
+    private static final long TFG$COUNTDOWN_MS_FIRST = 10_000L;
 
     @Unique
     private long tfg$launchStartMs = -1L;
+
+    @Unique
+    private long tfg$countdownMs = TFG$COUNTDOWN_MS_DEFAULT;
 
     @Shadow
     public abstract int launchTicks();
@@ -135,6 +143,9 @@ public abstract class RocketMixin extends Entity {
 
     @Inject(method = "initiateLaunchSequence", at = @At("RETURN"))
     private void tfg$recordLaunchStart(CallbackInfo ci) {
+        Player pilot = (Player) tfg$self.getControllingPassenger();
+        tfg$countdownMs = (pilot != null && LaunchingDimensionHandler.getAllSpawnLocations((net.minecraft.server.level.ServerPlayer) pilot).isEmpty()) ? TFG$COUNTDOWN_MS_FIRST
+                : TFG$COUNTDOWN_MS_DEFAULT;
         tfg$launchStartMs = System.currentTimeMillis();
     }
 
@@ -145,7 +156,7 @@ public abstract class RocketMixin extends Entity {
             entityData.set((EntityDataAccessor<Integer>) key, (Integer) value);
             return;
         }
-        entityData.set((EntityDataAccessor<Integer>) key, (int) ((TFG$COUNTDOWN_MS - (System.currentTimeMillis() - tfg$launchStartMs)) / 50L));
+        entityData.set((EntityDataAccessor<Integer>) key, (int) ((tfg$countdownMs - (System.currentTimeMillis() - tfg$launchStartMs)) / 50L));
     }
 
 }


### PR DESCRIPTION
https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4247

made the rockets launch in 10s real-time normally and 3s real-time if a player has already used a rocket (has a set landing location on any planet)


original tick:
```java
   public void tick() {
      super.tick();
      this.launchPadTick();
      if (this.canLaunch()) {
         this.initiateLaunchSequence();
         this.showFuelMessage = false;
      } else if (this.showFuelMessage && !this.level().isClientSide() && this.passengerHasSpaceDown()) {
         LivingEntity var2 = this.getControllingPassenger();
         if (var2 instanceof Player) {
            Player player = (Player)var2;
            player.displayClientMessage(ConstantComponents.NOT_ENOUGH_FUEL, true);
         }
      }

      if (this.isLaunching()) {
         this.entityData.set(LAUNCH_TICKS, this.launchTicks() - 1);
         if (this.launchTicks() <= 0) {
            this.launch();
         }

         this.spawnSmokeParticles();
      } else if (this.hasLaunched()) {
         this.flightTick();
      }

      if (!this.level().isClientSide()) {
         FluidUtils.moveItemToContainer(this.inventory, this.fluidContainer, 0, 1, 0);
         FluidUtils.moveContainerToItem(this.inventory, this.fluidContainer, 0, 1, 0);
         FluidHolder fluidHolder = this.fluidContainer.getFirstFluid();
         this.entityData.set(FUEL, fluidHolder.getFluidAmount());
         this.entityData.set(FUEL_TYPE, BuiltInRegistries.FLUID.getKey(fluidHolder.getFluid()).toString());
      }

   }
   ```