### PR TITLE
Make player temperature accurate inside the EBF

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/command/AmbientalDump.java
+++ b/src/main/java/su/terrafirmagreg/core/common/command/AmbientalDump.java
@@ -101,7 +101,7 @@ public class AmbientalDump {
     private static @Nonnull MutableComponent formatTempModifierStorage(String text, TempModifierStorage storage) {
         MutableComponent line = Component.literal(text).append("\n");
         for (TempModifier mod : storage) {
-            line.append(formatTempModifier("-", Optional.of(mod))).append("\n");
+            line.append(formatTempModifier("-", Optional.of(mod)));
         }
         return line;
     }

--- a/src/main/java/su/terrafirmagreg/tfcambiental/api/BlockTemperatureProvider.java
+++ b/src/main/java/su/terrafirmagreg/tfcambiental/api/BlockTemperatureProvider.java
@@ -14,8 +14,13 @@ import java.util.stream.Stream;
 import com.eerussianguy.firmalife.common.blocks.OvenBottomBlock;
 import com.gregtechceu.gtceu.api.block.property.GTBlockStateProperties;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
+import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.multiblock.CoilWorkableElectricMultiblockMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTMachines;
+import com.gregtechceu.gtceu.common.data.machines.GCYMMachines;
+import com.gregtechceu.gtceu.common.data.machines.GTMultiMachines;
 
 import net.dries007.tfc.common.blockentities.BloomeryBlockEntity;
 import net.dries007.tfc.common.blockentities.CharcoalForgeBlockEntity;
@@ -102,6 +107,7 @@ public interface BlockTemperatureProvider {
                 addScaled(storage, handleBloomery(player, blockEntity), distanceMultiplier);
                 addScaled(storage, handleLitBlock(player, blockEntity), distanceMultiplier);
                 addScaled(storage, handleIHeatBlock(player, blockEntity), distanceMultiplier);
+                storage.add(handleMultiblockInside(player, blockEntity));
             }
         }
 
@@ -357,5 +363,29 @@ public interface BlockTemperatureProvider {
         }
 
         return Optional.empty();
+    }
+
+    static Optional<TempModifier> handleMultiblockInside(Player player, BlockEntity blockEntity) {
+        if (blockEntity instanceof IMachineBlockEntity machineBE &&
+                machineBE.getMetaMachine() instanceof WorkableElectricMultiblockMachine machine &&
+                machine.isFormed()
+                && machine.getMultiblockState().isPosInCache(player.blockPosition())
+                && machine.getRecipeLogic().isWorking()) {
+
+            float temp;
+
+            if (machine.getDefinition() == GCYMMachines.MEGA_VACUUM_FREEZER) {
+                temp = -273.0f;
+            } else if (machine.getDefinition() == GTMultiMachines.VACUUM_FREEZER) {
+                temp = -150.0f;
+            } else if (machine instanceof CoilWorkableElectricMultiblockMachine coilMachine) {
+                temp = coilMachine.getCoilType().getCoilTemperature();
+            } else {
+                return TempModifier.none();
+            }
+
+            return Optional.of(new TempModifier(temp, 100f));
+        }
+        return TempModifier.none();
     }
 }

--- a/src/main/java/su/terrafirmagreg/tfcambiental/capability/TemperatureCapability.java
+++ b/src/main/java/su/terrafirmagreg/tfcambiental/capability/TemperatureCapability.java
@@ -53,7 +53,6 @@ public class TemperatureCapability implements ICapabilitySerializable<CompoundTa
 
     public static final float BAD_MULTIPLIER = 0.001f;
     public static final float GOOD_MULTIPLIER = 0.002f;
-    public static final float CHANGE_CAP = 7.5f;
     public static final float WET_CHANGE_CAP = 2.0f;
     public static final float HIGH_CHANGE = 0.20f;
 
@@ -63,7 +62,7 @@ public class TemperatureCapability implements ICapabilitySerializable<CompoundTa
 
     public float getTemperatureChange() {
         float speed = getPotency() * 0.025f * TFCAmbientalConfig.COMMON.temperatureChangeSpeed.get().floatValue();
-        float change = Math.min(CHANGE_CAP, Math.max(-CHANGE_CAP, getTargetTemperature() - this.temperature));
+        float change = getTargetTemperature() - this.temperature;
         float newTemp = this.temperature + change;
         float average = TFCAmbientalConfig.COMMON.averageTemperature.get().floatValue();
         if ((this.temperature < average && newTemp > this.temperature)
@@ -113,10 +112,11 @@ public class TemperatureCapability implements ICapabilitySerializable<CompoundTa
 
         if ((this.target > this.temperature && this.temperature > TFCAmbientalConfig.COMMON.hotThreshold.get().floatValue())
                 || (this.target < this.temperature && this.temperature < TFCAmbientalConfig.COMMON.coolThreshold.get().floatValue())) {
-            this.potency = 1f;
+            this.potency /= 4.0f;
         }
 
         this.potency = Math.max(1f, this.potency);
+        this.target = Math.max(this.target, -273.15f);
 
         if (fullyInsulated) {
             this.target = Mth.clamp(this.target, 5f, 25f);
@@ -230,31 +230,28 @@ public class TemperatureCapability implements ICapabilitySerializable<CompoundTa
                 }
             }
 
+            float burnThreshold = TFCAmbientalConfig.COMMON.burnThreshold.get().floatValue();
+            float freezeThreshold = TFCAmbientalConfig.COMMON.freezeThreshold.get().floatValue();
+            float average = TFCAmbientalConfig.COMMON.averageTemperature.get().floatValue();
+            if ((this.temperature - burnThreshold) / (burnThreshold - average) > player.getRandom().nextFloat() * 40f) {
+                player.hurt(new DamageSource(player.level().registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(TFCAmbiental.HOT)),
+                        1 + (this.temperature - burnThreshold) / (burnThreshold - average) / 20);
+                if (player.getFoodData() instanceof TFCFoodData stats) {
+                    stats.addThirst(-2);
+                }
+            } else if ((this.temperature - freezeThreshold) / (freezeThreshold - average) > player.getRandom().nextFloat() * 40f) {
+                player.hurt(new DamageSource(player.level().registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(TFCAmbiental.FREEZE)),
+                        1 + (this.temperature - freezeThreshold) / (freezeThreshold - average) / 20);
+                if (player.getFoodData() instanceof TFCFoodData stats) {
+                    stats.setFoodLevel(stats.getFoodLevel() - 1);
+                }
+            }
+
             if (tick <= 20) {
                 tick++;
                 return;
             } else {
                 tick = 0;
-                if (this.damageTick > 40) {
-                    this.damageTick = 0;
-                    if (this.getTemperature() > TFCAmbientalConfig.COMMON.burnThreshold.get().floatValue()) {
-                        player.hurt(new DamageSource(player.level().registryAccess()
-                                .registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(TFCAmbiental.HOT)), 4f);
-                    } else if (this.getTemperature() < TFCAmbientalConfig.COMMON.freezeThreshold.get().floatValue()) {
-                        player.hurt(new DamageSource(player.level().registryAccess()
-                                .registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(TFCAmbiental.FREEZE)), 4f);
-                    }
-                    if (player.getFoodData() instanceof TFCFoodData stats) {
-                        if (this.getTemperature() > TFCAmbientalConfig.COMMON.burnThreshold.get().floatValue()) {
-                            stats.addThirst(-8);
-                        } else if (this.getTemperature() < TFCAmbientalConfig.COMMON.freezeThreshold.get()
-                                .floatValue()) {
-                            stats.setFoodLevel(stats.getFoodLevel() - 1);
-                        }
-                    }
-                } else {
-                    this.damageTick++;
-                }
             }
             this.evaluateModifiers();
             sync();

--- a/src/main/java/su/terrafirmagreg/tfcambiental/capability/TemperatureCapability.java
+++ b/src/main/java/su/terrafirmagreg/tfcambiental/capability/TemperatureCapability.java
@@ -233,13 +233,13 @@ public class TemperatureCapability implements ICapabilitySerializable<CompoundTa
             float burnThreshold = TFCAmbientalConfig.COMMON.burnThreshold.get().floatValue();
             float freezeThreshold = TFCAmbientalConfig.COMMON.freezeThreshold.get().floatValue();
             float average = TFCAmbientalConfig.COMMON.averageTemperature.get().floatValue();
-            if ((this.temperature - burnThreshold) / (burnThreshold - average) > player.getRandom().nextFloat() * 40f) {
+            if (this.temperature > burnThreshold && 1 + (this.temperature - burnThreshold) / (burnThreshold - average) > player.getRandom().nextFloat() * 40f) {
                 player.hurt(new DamageSource(player.level().registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(TFCAmbiental.HOT)),
                         1 + (this.temperature - burnThreshold) / (burnThreshold - average) / 20);
                 if (player.getFoodData() instanceof TFCFoodData stats) {
                     stats.addThirst(-2);
                 }
-            } else if ((this.temperature - freezeThreshold) / (freezeThreshold - average) > player.getRandom().nextFloat() * 40f) {
+            } else if (this.temperature < freezeThreshold && 1 + (this.temperature - freezeThreshold) / (freezeThreshold - average) > player.getRandom().nextFloat() * 40f) {
                 player.hurt(new DamageSource(player.level().registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(TFCAmbiental.FREEZE)),
                         1 + (this.temperature - freezeThreshold) / (freezeThreshold - average) / 20);
                 if (player.getFoodData() instanceof TFCFoodData stats) {


### PR DESCRIPTION
When the player crawls into any multiblock that uses coils they will heat up to the coil temperature while the multiblock is active. If they crawl into a vacuum freezer they'll cool down.

Additionally:
- changed heatstroke/frostbite behavior so that while above 30C instead of dealing 2 hearts every ~43s it now deals **half a heart every ~2s**, increasing every additional 15C. The previous behavior was probably a bug.
- potency is no longer set to 1 when over 25C, instead it's divided by 4. Originally it always took at least ~11 minutes to heat up from 25C to 30C, this makes heating up much faster when inside a multiblock for example. For most cases (such as exploring the beneath) this is effectively unchanged.