### PR TITLE
Fix the the kinetic bridge not working with reverse rotation

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/create_connected/KineticBridgeDestinationBlockEntityMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/create_connected/KineticBridgeDestinationBlockEntityMixin.java
@@ -21,6 +21,6 @@ public abstract class KineticBridgeDestinationBlockEntityMixin extends Generatin
 
     @Override
     public float getMaxCapacityFromBlock(Block block) {
-        return getGeneratedSpeed() * calculateAddedStressCapacity();
+        return Math.abs(getGeneratedSpeed()) * calculateAddedStressCapacity();
     }
 }


### PR DESCRIPTION
fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4389

create uses negative speeds to indicate a shaft is rotating counter-clockwise