### PR TITLE
fix #4304: Beneath custom spawn login/respawn race 

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/common/ForgeCommonEventListener.java
@@ -9,7 +9,6 @@ import net.dries007.tfc.common.items.TFCItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -83,28 +82,7 @@ public final class ForgeCommonEventListener {
             //Checks if the player is in a custom dimension spawn,
             // and puts them at that pos when they first join
             GlobalPos spawnPos = CustomSpawnSaveHandler.getSpawnPos(Objects.requireNonNull(player.getServer()).overworld());
-
-            if (!spawnPos.dimension().equals(ServerLevel.OVERWORLD)) {
-                CompoundTag playerData = player.getPersistentData();
-                CompoundTag tfgPlayerData;
-
-                if (playerData.contains(TFGCore.MOD_ID, CompoundTag.TAG_COMPOUND)) {
-                    tfgPlayerData = playerData.getCompound(TFGCore.MOD_ID);
-                    TFGCore.LOGGER.info("hasJoinedBefore: {}", tfgPlayerData.getBoolean("hasJoinedBefore"));
-                } else {
-                    tfgPlayerData = new CompoundTag();
-                    playerData.put(TFGCore.MOD_ID, tfgPlayerData);
-                }
-
-                if (!tfgPlayerData.getBoolean("hasJoinedBefore")) {
-                    tfgPlayerData.putBoolean("hasJoinedBefore", true);
-                    playerData.put(TFGCore.MOD_ID, tfgPlayerData);
-
-                    CustomSpawnHelper.respawnTeleporter(player, player.getServer().getLevel(spawnPos.dimension()), spawnPos);
-
-                }
-
-            }
+            CustomSpawnHelper.tryFirstJoinTeleport(player, spawnPos);
         }
     }
 
@@ -138,6 +116,9 @@ public final class ForgeCommonEventListener {
     @SubscribeEvent
     public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
         NutrientEffectsHandler.removeFromPlayer(event.getEntity());
+        if (event.getEntity() instanceof ServerPlayer player) {
+            CustomSpawnHelper.removeFirstJoinTeleport(player.getUUID());
+        }
     }
 
     @SubscribeEvent
@@ -146,8 +127,15 @@ public final class ForgeCommonEventListener {
             MinecraftServer server = player.getServer();
             GlobalPos worldSpawn = CustomSpawnSaveHandler.getSpawnPos(Objects.requireNonNull(server).overworld());
 
-            if ((worldSpawn.dimension().equals(ServerLevel.OVERWORLD) || player.getRespawnPosition() != null))
+            if (worldSpawn.dimension().equals(ServerLevel.OVERWORLD)) {
                 return;
+            }
+            if (CustomSpawnHelper.respawnedAtPersonalSpawn(player)) {
+                return;
+            }
+            if (player.level().dimension().equals(worldSpawn.dimension())) {
+                return;
+            }
             CustomSpawnHelper.respawnTeleporter(player, server.getLevel(worldSpawn.dimension()), worldSpawn);
         }
     }
@@ -176,9 +164,15 @@ public final class ForgeCommonEventListener {
 
             var targetLevel = server.getLevel(spawnPos.dimension());
             if (targetLevel == serverLevel) {
-                if (!spawnPos.equals(CustomSpawnHelper.BENEATH_PLACEHOLDER)
-                        && !spawnPos.equals(CustomSpawnHelper.MARS_PLACEHOLDER)) {
+                if (!CustomSpawnHelper.isUnresolvedPlaceholder(spawnPos)) {
                     TFGCore.LOGGER.info("Found exists spawn point: {}", spawnPos);
+                    CustomSpawnHelper.processPendingFirstJoinTeleports(server, spawnPos);
+                    return;
+                }
+                if (!spawnPos.dimension().equals(ServerLevel.NETHER)) {
+                    TFGCore.LOGGER.warn(
+                            "Custom spawn in {} is still unresolved; nether biome search does not apply",
+                            spawnPos.dimension().location());
                     return;
                 }
                 RandomSource random = new XoroshiroRandomSource(targetLevel.getSeed());
@@ -246,7 +240,9 @@ public final class ForgeCommonEventListener {
                 }
 
                 TFGCore.LOGGER.info("Found valid spawn point: {}", validSpawn);
-                CustomSpawnSaveHandler.setSpawnPos(server.overworld(), GlobalPos.of(spawnPos.dimension(), validSpawn));
+                GlobalPos resolvedSpawn = GlobalPos.of(spawnPos.dimension(), validSpawn);
+                CustomSpawnSaveHandler.setSpawnPos(server.overworld(), resolvedSpawn);
+                CustomSpawnHelper.processPendingFirstJoinTeleports(server, resolvedSpawn);
             }
         }
     }

--- a/src/main/java/su/terrafirmagreg/core/utils/CustomSpawnHelper.java
+++ b/src/main/java/su/terrafirmagreg/core/utils/CustomSpawnHelper.java
@@ -12,9 +12,11 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.core.QuartPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
@@ -26,12 +28,99 @@ import net.minecraftforge.common.util.ITeleporter;
 
 import earth.terrarium.adastra.api.planets.Planet;
 
+import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.config.TFGConfig;
 
 public class CustomSpawnHelper {
 
     public static final GlobalPos BENEATH_PLACEHOLDER = GlobalPos.of(ServerLevel.NETHER, BlockPos.ZERO);
     public static final GlobalPos MARS_PLACEHOLDER = GlobalPos.of(Planet.MARS, BlockPos.ZERO);
+
+    private static final Set<UUID> PENDING_FIRST_JOIN_TELEPORTS = new HashSet<>();
+
+    public static boolean isUnresolvedPlaceholder(GlobalPos pos) {
+        return pos.equals(BENEATH_PLACEHOLDER) || pos.equals(MARS_PLACEHOLDER);
+    }
+
+    public static void queueFirstJoinTeleport(UUID playerId) {
+        PENDING_FIRST_JOIN_TELEPORTS.add(playerId);
+    }
+
+    public static void removeFirstJoinTeleport(UUID playerId) {
+        PENDING_FIRST_JOIN_TELEPORTS.remove(playerId);
+    }
+
+    public static boolean respawnedAtPersonalSpawn(ServerPlayer player) {
+        return player.getRespawnPosition() != null
+                && player.getRespawnDimension().equals(player.level().dimension());
+    }
+
+    public static void processPendingFirstJoinTeleports(MinecraftServer server, GlobalPos worldSpawn) {
+        if (isUnresolvedPlaceholder(worldSpawn)) {
+            return;
+        }
+
+        ServerLevel targetLevel = server.getLevel(worldSpawn.dimension());
+        if (targetLevel == null) {
+            return;
+        }
+
+        for (UUID playerId : Set.copyOf(PENDING_FIRST_JOIN_TELEPORTS)) {
+            ServerPlayer player = server.getPlayerList().getPlayer(playerId);
+            PENDING_FIRST_JOIN_TELEPORTS.remove(playerId);
+            if (player != null) {
+                tryFirstJoinTeleport(player, worldSpawn);
+            }
+        }
+    }
+
+    /**
+     * Teleports a player to the world's custom spawn on their first join.
+     *
+     * @return {@code true} if the player was teleported
+     */
+    public static boolean tryFirstJoinTeleport(ServerPlayer player, GlobalPos spawnPos) {
+        if (spawnPos.dimension().equals(ServerLevel.OVERWORLD)) {
+            return false;
+        }
+
+        if (isUnresolvedPlaceholder(spawnPos)) {
+            queueFirstJoinTeleport(player.getUUID());
+            TFGCore.LOGGER.debug("Deferring first-join teleport for {} until custom spawn is resolved",
+                    player.getGameProfile().getName());
+            return false;
+        }
+
+        var tfgData = getTfgPlayerData(player);
+        if (tfgData.getBoolean("hasJoinedBefore")) {
+            return false;
+        }
+
+        if (player.level().dimension().equals(spawnPos.dimension())) {
+            tfgData.putBoolean("hasJoinedBefore", true);
+            return false;
+        }
+
+        MinecraftServer server = Objects.requireNonNull(player.getServer());
+        ServerLevel targetLevel = server.getLevel(spawnPos.dimension());
+        if (targetLevel == null) {
+            queueFirstJoinTeleport(player.getUUID());
+            return false;
+        }
+
+        respawnTeleporter(player, targetLevel, spawnPos);
+        tfgData.putBoolean("hasJoinedBefore", true);
+        TFGCore.LOGGER.info("First-join teleport for {} to {}", player.getGameProfile().getName(), spawnPos);
+        return true;
+    }
+
+    private static CompoundTag getTfgPlayerData(ServerPlayer player) {
+        CompoundTag playerData = player.getPersistentData();
+        if (!playerData.contains(TFGCore.MOD_ID, CompoundTag.TAG_COMPOUND)) {
+            playerData.put(TFGCore.MOD_ID, new CompoundTag());
+        }
+        return playerData.getCompound(TFGCore.MOD_ID);
+    }
 
     public static void respawnTeleporter(ServerPlayer player, ServerLevel targetLevel, GlobalPos worldSpawn) {
         //System.out.println("attempting to spawn player at: " + worldSpawn);


### PR DESCRIPTION
Fixes Beneath spawn being re-applied on relog/death. Defers first-join teleport until custom spawn is resolved, respects bed respawn, and leaves Overworld spawn presets untouched.