### PR TITLE
Fix TFGWood door loot tables (Fix Modpack-Modern/#4494)

### DIFF
--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/door/araucaria.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/door/araucaria.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/door/araucaria",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "tfg:wood/door/araucaria"
         }
       ],

--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/door/beech.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/door/beech.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/door/beech",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "tfg:wood/door/beech"
         }
       ],

--- a/src/generated/resources/data/tfg/loot_tables/blocks/wood/door/mahoe.json
+++ b/src/generated/resources/data/tfg/loot_tables/blocks/wood/door/mahoe.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "tfg:wood/door/mahoe",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "tfg:wood/door/mahoe"
         }
       ],

--- a/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/blocks/TFGBlocks_Wood.java
@@ -289,6 +289,7 @@ public class TFGBlocks_Wood {
                 .addLayer(() -> RenderType::cutout)
                 .tag(BlockTags.DOORS)
                 .tag(BlockTags.MINEABLE_WITH_AXE)
+                .loot((table, block) -> table.add(block, table.createDoorTable(block)))
                 .item()
                 .model((ctx, prov) -> prov.withExistingParent(ctx.getName(), ResourceLocation.withDefaultNamespace("item/generated")).texture("layer0",
                         TFGCore.id("item/wood/door/" + wood.serializedName)))


### PR DESCRIPTION
## What is the new behavior?
Makes TFGWood doors use createDoorTable, so that they only drop a single door, rather than two.

## Outcome
Fixes [TerraFirmaGreg-Team/Modpack-Modern#4493](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4494)