### PR TITLE
Effect Changes

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/data/TFGEffects.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/TFGEffects.java
@@ -18,10 +18,10 @@ public class TFGEffects {
 
     // Beneficial
     public static final RegistryObject<MobEffect> COOLING = register("cooling",
-            () -> new TemperatureChangeEffect(MobEffectCategory.BENEFICIAL, 0xAEBDD, 5f, false));
+            () -> new TemperatureChangeEffect(MobEffectCategory.BENEFICIAL, 0xAEBDD, 5f, false, 10f));
 
     public static final RegistryObject<MobEffect> WARMING = register("warming",
-            () -> new TemperatureChangeEffect(MobEffectCategory.BENEFICIAL, 0xEDA02D, 25f, true));
+            () -> new TemperatureChangeEffect(MobEffectCategory.BENEFICIAL, 0xEDA02D, 25f, true, 10f));
 
     public static final RegistryObject<MobEffect> QUENCHED = register("quenched",
             () -> new MobEffect(MobEffectCategory.BENEFICIAL, 0x3ED5E0) {
@@ -29,10 +29,10 @@ public class TFGEffects {
 
     // Harmful
     public static final RegistryObject<MobEffect> FREEZING = register("freezing",
-            () -> new TemperatureChangeEffect(MobEffectCategory.HARMFUL, 0xA8D9FF, -20f, false));
+            () -> new TemperatureChangeEffect(MobEffectCategory.HARMFUL, 0xA8D9FF, -20f, false, 50f));
 
     public static final RegistryObject<MobEffect> BLAZING = register("blazing",
-            () -> new TemperatureChangeEffect(MobEffectCategory.HARMFUL, 0xF27552, 60f, true));
+            () -> new TemperatureChangeEffect(MobEffectCategory.HARMFUL, 0xF27552, 60f, true, 50f));
 
     public static final RegistryObject<MobEffect> INSTANT_RADIATION = register("instant_radiation",
             () -> new InstantDamageEffect(MobEffectCategory.HARMFUL, 0x94fc03));

--- a/src/main/java/su/terrafirmagreg/core/common/effect/FinalMomentsEffect.java
+++ b/src/main/java/su/terrafirmagreg/core/common/effect/FinalMomentsEffect.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.NotNull;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.entity.player.Player;
 
 /**
@@ -18,14 +17,17 @@ public class FinalMomentsEffect extends MobEffect {
     }
 
     @Override
-    public void removeAttributeModifiers(@NotNull LivingEntity entity, @NotNull AttributeMap attributeMap, int amplifier) {
-        super.removeAttributeModifiers(entity, attributeMap, amplifier);
+    public void applyEffectTick(@NotNull LivingEntity entity, int amplifier) {
         if (!entity.level().isClientSide && entity.isAlive() && !entity.isInvulnerable()) {
-            if (entity instanceof Player player) {
-                if (player.getAbilities().invulnerable)
-                    return;
+            if (entity instanceof Player player && player.getAbilities().invulnerable) {
+                return;
             }
-            entity.kill();
+            entity.hurt(entity.damageSources().magic(), Float.MAX_VALUE);
         }
+    }
+
+    @Override
+    public boolean isDurationEffectTick(int duration, int amplifier) {
+        return duration == 1;
     }
 }

--- a/src/main/java/su/terrafirmagreg/core/common/effect/TemperatureChangeEffect.java
+++ b/src/main/java/su/terrafirmagreg/core/common/effect/TemperatureChangeEffect.java
@@ -1,17 +1,14 @@
 package su.terrafirmagreg.core.common.effect;
 
+import lombok.Getter;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
-import net.minecraft.world.entity.LivingEntity;
 
-import su.terrafirmagreg.tfcambiental.capability.TemperatureCapability;
-
+@Getter
 public class TemperatureChangeEffect extends MobEffect {
 
-    private static final float deltaTemp = 2;
-    private static final int defaultTime = 20;
-
     private final float targetTemperature;
+    private final float temperatureDelta;
     private final boolean isHeating;
 
     /**
@@ -20,41 +17,13 @@ public class TemperatureChangeEffect extends MobEffect {
      * @param pColor The color of the effect.
      * @param targetTemperature The target temperature for the effect.
      * @param isHeating Whether the effect is heating or cooling.
+     * @param temperatureDelta The amount of temperature change per amplifier level.
      */
-    public TemperatureChangeEffect(MobEffectCategory pCategory, int pColor, float targetTemperature, boolean isHeating) {
+    public TemperatureChangeEffect(MobEffectCategory pCategory, int pColor, float targetTemperature, boolean isHeating, float temperatureDelta) {
         super(pCategory, pColor);
         this.targetTemperature = targetTemperature;
         this.isHeating = isHeating;
+        this.temperatureDelta = temperatureDelta;
     }
 
-    /**
-     * Applies the effect tick to the living entity.
-     * @param livingEntity The entity to apply the effect to.
-     * @param amplifier The amplifier level of the effect.
-     */
-    @Override
-    public void applyEffectTick(LivingEntity livingEntity, int amplifier) {
-        TemperatureCapability tempCap = livingEntity.getCapability(TemperatureCapability.CAPABILITY)
-                .orElse(new TemperatureCapability());
-
-        float currentTemp = tempCap.getTemperature();
-        float change = deltaTemp * (amplifier + 1);
-
-        if (isHeating) {
-            // If heating check max temp.
-            if (currentTemp < targetTemperature) {
-                tempCap.setTemperature(Math.min(currentTemp + change, targetTemperature));
-            }
-        } else {
-            // If cooling check min temp.
-            if (currentTemp > targetTemperature) {
-                tempCap.setTemperature(Math.max(currentTemp - change, targetTemperature));
-            }
-        }
-    }
-
-    @Override
-    public boolean isDurationEffectTick(int duration, int amplitude) {
-        return duration % defaultTime == 0;
-    }
 }

--- a/src/main/java/su/terrafirmagreg/core/common/effect/TemperatureChangeEffect.java
+++ b/src/main/java/su/terrafirmagreg/core/common/effect/TemperatureChangeEffect.java
@@ -1,8 +1,9 @@
 package su.terrafirmagreg.core.common.effect;
 
-import lombok.Getter;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
+
+import lombok.Getter;
 
 @Getter
 public class TemperatureChangeEffect extends MobEffect {

--- a/src/main/java/su/terrafirmagreg/core/common/food/nutrient/NutrientEffectsHandler.java
+++ b/src/main/java/su/terrafirmagreg/core/common/food/nutrient/NutrientEffectsHandler.java
@@ -242,7 +242,7 @@ public final class NutrientEffectsHandler {
 
             switch (nutrient.getSerializedName()) {
                 case "deadly" -> {
-                    if (!player.getAbilities().invulnerable && ENABLE_FOOD_DEBUFFS) {
+                    if (!player.getAbilities().invulnerable && ENABLE_FOOD_DEBUFFS && !player.hasEffect(TFGEffects.FINAL_MOMENTS.get())) {
                         player.addEffect(new MobEffectInstance(TFGEffects.FINAL_MOMENTS.get(), Math.max((int) (9600 / (value)), 600), 0, true, true));
                     }
                 }
@@ -557,7 +557,7 @@ public final class NutrientEffectsHandler {
             }
         }
 
-        if (toxins > 0.99f && !player.getAbilities().invulnerable) {
+        if (toxins > 0.99f && !player.getAbilities().invulnerable && !player.hasEffect(TFGEffects.FINAL_MOMENTS.get())) {
             NutritionDataExtension.setExtendedNutrient(nutritionData, toxinsNutrient, 0.90f);
             player.addEffect(new MobEffectInstance(TFGEffects.FINAL_MOMENTS.get(), 18000, 0, false, true));
         }

--- a/src/main/java/su/terrafirmagreg/core/common/food/nutrient/NutrientEffectsHandler.java
+++ b/src/main/java/su/terrafirmagreg/core/common/food/nutrient/NutrientEffectsHandler.java
@@ -557,9 +557,11 @@ public final class NutrientEffectsHandler {
             }
         }
 
-        if (toxins > 0.99f && !player.getAbilities().invulnerable && !player.hasEffect(TFGEffects.FINAL_MOMENTS.get())) {
+        if (toxins > 0.99f && !player.getAbilities().invulnerable) {
             NutritionDataExtension.setExtendedNutrient(nutritionData, toxinsNutrient, 0.90f);
-            player.addEffect(new MobEffectInstance(TFGEffects.FINAL_MOMENTS.get(), 18000, 0, false, true));
+            if (!player.hasEffect(TFGEffects.FINAL_MOMENTS.get())) {
+                player.addEffect(new MobEffectInstance(TFGEffects.FINAL_MOMENTS.get(), 18000, 0, false, true));
+            }
         }
     }
 

--- a/src/main/java/su/terrafirmagreg/tfcambiental/api/EffectTemperatureProvider.java
+++ b/src/main/java/su/terrafirmagreg/tfcambiental/api/EffectTemperatureProvider.java
@@ -45,6 +45,6 @@ public interface EffectTemperatureProvider {
     static Optional<TempModifier> getModifier(TemperatureChangeEffect effect, int amplifier) {
         float delta = effect.getTemperatureDelta() * (amplifier + 1);
         float heatingMulti = effect.isHeating() ? 1 : -1;
-        return TempModifier.defined(heatingMulti * delta, 0);
+        return TempModifier.defined(heatingMulti * delta, delta);
     }
 }

--- a/src/main/java/su/terrafirmagreg/tfcambiental/api/EffectTemperatureProvider.java
+++ b/src/main/java/su/terrafirmagreg/tfcambiental/api/EffectTemperatureProvider.java
@@ -1,0 +1,50 @@
+package su.terrafirmagreg.tfcambiental.api;
+
+import java.util.Optional;
+
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.player.Player;
+
+import su.terrafirmagreg.core.common.effect.TemperatureChangeEffect;
+import su.terrafirmagreg.tfcambiental.modifier.TempModifier;
+import su.terrafirmagreg.tfcambiental.modifier.TempModifierStorage;
+
+/**
+ * Interface for providing temperature modifiers based on active effects.
+ */
+public interface EffectTemperatureProvider {
+
+    /**
+     * Evaluates all active effects on the player and adds their temperature modifiers to the storage.
+     * @param player The player to check for effects.
+     * @param storage The ambiental {@link TempModifierStorage}.
+     * @param currentTemp The player's current temperature.
+     */
+    static void evaluateAll(Player player, TempModifierStorage storage, float currentTemp) {
+        for (MobEffectInstance effectInstance : player.getActiveEffects()) {
+            if (effectInstance.getEffect() instanceof TemperatureChangeEffect tempEffect) {
+                if (tempEffect.isHeating()) {
+                    if (currentTemp < tempEffect.getTargetTemperature()) {
+                        storage.add(getModifier(tempEffect, effectInstance.getAmplifier()));
+                    }
+                } else {
+                    if (currentTemp > tempEffect.getTargetTemperature()) {
+                        storage.add(getModifier(tempEffect, effectInstance.getAmplifier()));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the temperature delta for a {@link TemperatureChangeEffect} and amplifier level.
+     * @param effect The TemperatureChangeEffect.
+     * @param amplifier The amplifier level of the effect.
+     * @return An Optional containing the temperature modifier.
+     */
+    static Optional<TempModifier> getModifier(TemperatureChangeEffect effect, int amplifier) {
+        float delta = effect.getTemperatureDelta() * (amplifier + 1);
+        float heatingMulti = effect.isHeating() ? 1 : -1;
+        return TempModifier.defined(heatingMulti * delta, 0);
+    }
+}

--- a/src/main/java/su/terrafirmagreg/tfcambiental/capability/TemperatureCapability.java
+++ b/src/main/java/su/terrafirmagreg/tfcambiental/capability/TemperatureCapability.java
@@ -25,6 +25,7 @@ import top.theillusivec4.curios.api.CuriosApi;
 import su.terrafirmagreg.tfcambiental.TFCAmbiental;
 import su.terrafirmagreg.tfcambiental.TFCAmbientalConfig;
 import su.terrafirmagreg.tfcambiental.api.BlockTemperatureProvider;
+import su.terrafirmagreg.tfcambiental.api.EffectTemperatureProvider;
 import su.terrafirmagreg.tfcambiental.api.EntityTemperatureProvider;
 import su.terrafirmagreg.tfcambiental.api.EnvironmentalTemperatureProvider;
 import su.terrafirmagreg.tfcambiental.api.EquipmentTemperatureProvider;
@@ -101,6 +102,7 @@ public class TemperatureCapability implements ICapabilitySerializable<CompoundTa
 
         EnvironmentalTemperatureProvider.evaluateAll(this.player, this.modifiers, nether);
         EquipmentTemperatureProvider.evaluateAll(this.player, this.modifiers);
+        EffectTemperatureProvider.evaluateAll(this.player, this.modifiers, this.temperature);
 
         if (!fullyInsulated) {
             ItemTemperatureProvider.evaluateAll(this.player, this.modifiers);


### PR DESCRIPTION
Temperate changing effects now provide a static +/- change to temperature when active like armor. Instead of continuosly applying temperature change until a target temp is reached.

Final moments has been adjusted to only kill on natural effect completion. Not on refreshes or clears. It also uses .hurt() instead of .kill() to maybe fix the corpse issue? idk.