### PR TITLE
Fix stuck-in-lander on planet arrival

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/ModUtilsMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/ModUtilsMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
@@ -54,7 +55,11 @@ public class ModUtilsMixin {
 
                     lander.setPos(pos);
                     targetLevel.addFreshEntity(lander);
-                    teleportedPlayer.startRiding(lander);
+                    targetLevel.getServer().tell(new TickTask(targetLevel.getServer().getTickCount() + 10, () -> {
+                        if (teleportedPlayer.isAlive() && lander.isAlive() && teleportedPlayer.getVehicle() == null) {
+                            teleportedPlayer.startRiding(lander, true);
+                        }
+                    }));
 
                     if (player != pilotPlayer)
                         continue;


### PR DESCRIPTION
ModUtils.land() spawned the lander and mounted the player in the same tick as the dimension change. On dedicated servers the client's entity tracker isn't established yet, so the lander entity is never sent to the client: the player rides a phantom vehicle - frozen movement (only head pitch works), can't dismount, 0-slot lander menu - and the only recovery is a relog.

Defer startRiding by 10 server ticks so the lander entity is tracked and sent to the client first, then mount. 10 ticks gives slower servers enough headroom.