### PR TITLE
Fix Ad Astra Lander

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/ModUtilsMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ad_astra/ModUtilsMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
@@ -54,7 +55,11 @@ public class ModUtilsMixin {
 
                     lander.setPos(pos);
                     targetLevel.addFreshEntity(lander);
-                    teleportedPlayer.startRiding(lander);
+                    targetLevel.getServer().tell(new TickTask(targetLevel.getServer().getTickCount() + 10, () -> {
+                        if (teleportedPlayer.isAlive() && lander.isAlive() && teleportedPlayer.getVehicle() == null) {
+                            teleportedPlayer.startRiding(lander, true);
+                        }
+                    }));
 
                     if (player != pilotPlayer)
                         continue;


### PR DESCRIPTION
Fix for https://github.com/orgs/TerraFirmaGreg-Team/projects/10/views/1?pane=issue&itemId=156729680&issue=TerraFirmaGreg-Team%7CModpack-Modern%7C3054

## What is the new behavior?

Fixes a hard freeze when arriving on a planet with an Ad Astra lander on dedicated servers. After landing, the player is mounted on a lander the client never receives, so they are stuck: movement is dead (only head pitch works), dismounting does nothing, the lander menu has 0 slots, and the only recovery is a relog.

Root cause: `ModUtils.land()` (which this mod already `@Overwrite`s) spawns the lander and mounts the player in the **same tick** as the dimension change. On a dedicated server the player's entity tracker in the destination level isn't established yet at that point, so the lander's spawn packet is never sent to the client — the player ends up riding a "phantom" vehicle.

## Implementation Details

The only change is in `ModUtils.land()`: instead of calling `startRiding` immediately after `addFreshEntity`, the mount is deferred to a later server tick via a `TickTask` (`server.getTickCount() + 10`), guarded by `isAlive()` and `getVehicle() == null` checks.

- Deferring the mount lets the entity tracker send the lander to the client before the passenger packet, so the client actually has the vehicle when it mounts.
- 10 ticks (~0.5 s) is deliberately generous to give slower/laggier servers headroom.
- The `isAlive()` / `getVehicle() == null` checks avoid mounting a discarded lander or double-mounting.
- The player is briefly unmounted (~0.5 s) and free-falls before snapping onto the lander, which falls with them, so it isn't noticeable in practice.

## Outcome

Fixes the "stuck riding an invisible lander / must relog after landing on a planet" bug on dedicated servers.
Tested on my own server.

## Potential Compatibility Issues

Minimal. The change is confined to the already-overwritten `ModUtils.land()`, adds no API or registry changes, and only shifts *when* the mount happens by a few ticks.

**Discord:** mixymixery