### PR TITLE
Drain energy instead of durability when logging with electric tools

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/fallingtrees/EventHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/fallingtrees/EventHandlerMixin.java
@@ -1,0 +1,28 @@
+package su.terrafirmagreg.core.mixins.common.fallingtrees;
+
+import java.util.function.Consumer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+import me.pandamods.fallingtrees.event.EventHandler;
+
+@Mixin(value = EventHandler.class, remap = false)
+public class EventHandlerMixin {
+
+    @Redirect(method = "makeTreeFall(Lme/pandamods/fallingtrees/api/Tree;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/world/entity/player/Player;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;hurtAndBreak(ILnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V", remap = true))
+    private static void tfg$logDamageLikeBlockBreak(ItemStack stack, int amount, LivingEntity entity, Consumer<LivingEntity> onBroken) {
+        if (stack.getItem() instanceof IGTTool) {
+            ToolHelper.damageItem(stack, entity, amount);
+        } else {
+            stack.hurtAndBreak(amount, entity, onBroken);
+        }
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -82,6 +82,7 @@
         "common.create_connected.KineticBridgeDestinationBlockEntityMixin",
         "common.createliquidfuel.LiquidBurnerFuelJsonLoaderMixin",
         "common.emi.ItemEmiStackMixin",
+        "common.fallingtrees.EventHandlerMixin",
         "common.fallingtrees.StandardTreeMixin",
         "common.firmaciv.BlockEventHandlerMixin",
         "common.firmalife.ClimateStationOxygenatedMixin",


### PR DESCRIPTION
## What is the new behavior?
Electric axes and chainsaws now consume energy instead of durability when
felling a tree, the same way they already consume energy when breaking a
single block. Previously the whole tree was charged to durability and no power
was used.

## Implementation Details
When a whole tree is felled, FallingTrees damages the tool once for the whole
tree through the vanilla path, which bypasses GregTech's energy handling. This
routes that damage through GregTech's own tool damage instead, so electric tools
spend energy (and non-GT axes keep working exactly as before).

## Outcome
Fixes electric axes/chainsaws using durability instead of power while logging.

Closes: TerraFirmaGreg-Team/Modpack-Modern#3293

## Potential Compatibility Issues
None — non-GregTech axes are unaffected and keep their vanilla behaviour.

Discord: mixymixery