### PR TITLE
Vulcanizer gas well tweaks

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/data/tfgt/TFGMultiMachines.java
+++ b/src/main/java/su/terrafirmagreg/core/common/data/tfgt/TFGMultiMachines.java
@@ -1286,7 +1286,10 @@ public class TFGMultiMachines {
             .multiblock("ore_processing_beneath", OreProcessingBeneathMachine::new)
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(TFGTRecipeTypes.ORE_PROCESSING_GAS)
-            .recipeModifiers(GTRecipeModifiers.OC_NON_PERFECT, OreProcessingBeneathMachine::recipeModifier)
+            .recipeModifiers(
+                    OreProcessingBeneathMachine::parallelModifier,
+                    GTRecipeModifiers.OC_NON_PERFECT,
+                    OreProcessingBeneathMachine::recipeModifier)
             .appearanceBlock(GCYMBlocks.CASING_INDUSTRIAL_STEAM)
             .tooltips(
                     Component.translatable("tfg.tooltip.machine.ore_proc_beneath_1"),

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/OreProcessingBeneathMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/electric/OreProcessingBeneathMachine.java
@@ -19,7 +19,9 @@ import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
+import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
@@ -47,6 +49,9 @@ public class OreProcessingBeneathMachine extends WorkableElectricMultiblockMachi
     private static final double MAX_RATIO = 0.85; // Over this amount the machine won't start
     private static final double OPTIMAL_RATIO = 0.50; // The percentage of fluid in the hatch so it's optimal
     private static final double SIGMA = 0.15; // Lower will make the curve harder
+
+    private static final int MAX_PARALLELS = 8; // Amount of parallel
+    private static final double PARALLEL_EU_DISCOUNT = 0.75;
 
     @Persisted
     @DescSynced
@@ -154,6 +159,29 @@ public class OreProcessingBeneathMachine extends WorkableElectricMultiblockMachi
     }
 
     // Recipe Modifier - So we can interact with the chancedOutput
+
+    public static @NotNull ModifierFunction parallelModifier(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
+        if (!(machine instanceof OreProcessingBeneathMachine processor)) {
+            return RecipeModifier.nullWrongType(OreProcessingBeneathMachine.class, machine);
+        }
+
+        int maxParallel = MAX_PARALLELS;
+        long recipeEUt = recipe.getInputEUt().getTotalEU();
+        if (recipeEUt > 0) {
+            long maxByEnergy = (long) (processor.getOverclockVoltage() / (recipeEUt * PARALLEL_EU_DISCOUNT));
+            maxParallel = (int) Math.min(MAX_PARALLELS, Math.max(1, maxByEnergy));
+        }
+
+        int parallels = ParallelLogic.getParallelAmount(machine, recipe, maxParallel);
+        if (parallels == 1)
+            return ModifierFunction.IDENTITY;
+
+        return ModifierFunction.builder()
+                .modifyAllContents(ContentModifier.multiplier(parallels))
+                .eutMultiplier(parallels * PARALLEL_EU_DISCOUNT)
+                .parallels(parallels)
+                .build();
+    }
 
     public static ModifierFunction recipeModifier(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
         if (!(machine instanceof OreProcessingBeneathMachine processor)) {

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/steam/GasWellMachine.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/multiblock/steam/GasWellMachine.java
@@ -20,6 +20,7 @@ import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.client.model.machine.MachineRenderState;
+import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
@@ -158,6 +159,14 @@ public class GasWellMachine extends MultiblockControllerMachine implements IDisp
                                 .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltip))));
             }
 
+            if (logic.isActive() && logic.isOutputBlocked()) {
+                Component tooltip = Component.translatable("tfg.machine.gas_well.output_full.tooltip")
+                        .withStyle(ChatFormatting.GRAY);
+                textList.add(Component.translatable("tfg.machine.gas_well.output_full")
+                        .withStyle(Style.EMPTY.withColor(ChatFormatting.RED)
+                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltip))));
+            }
+
             Component waterInfo = Component.literal(GasWellRecipeLogic.FLUID_CONSUMPTION_PER_TICK + " mB/t")
                     .withStyle(ChatFormatting.BLUE);
             Component steamInfo = Component.literal(GasWellRecipeLogic.FLUID_CONSUMPTION_PER_TICK * 2 + " mB/t")
@@ -182,10 +191,16 @@ public class GasWellMachine extends MultiblockControllerMachine implements IDisp
                 if (entry != null && entry.getDefinition() != null) {
                     var veinFluid = entry.getDefinition().getStoredFluid().get();
                     if (veinFluid != null) {
+                        var naturalGas = GTMaterials.NaturalGas.getFluid();
+                        boolean isPumpable = naturalGas != null && veinFluid.isSame(naturalGas);
+
+                        Component fluidTooltip = Component.translatable("tfg.machine.gas_well.fluid.tooltip")
+                                .withStyle(ChatFormatting.GRAY);
                         Component fluidInfo = veinFluid.getFluidType().getDescription().copy()
-                                .withStyle(ChatFormatting.GREEN);
+                                .withStyle(isPumpable ? ChatFormatting.GREEN : ChatFormatting.RED);
                         textList.add(Component.translatable("gtceu.multiblock.fluid_rig.drilled_fluid", fluidInfo)
-                                .withStyle(ChatFormatting.GRAY));
+                                .withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)
+                                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, fluidTooltip))));
 
                         int produced = Math.max(
                                 entry.getDefinition().getDepletedYield(),

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/trait/GasWellRecipeLogic.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/trait/GasWellRecipeLogic.java
@@ -25,6 +25,7 @@ public class GasWellRecipeLogic {
 
     private int timer = 0;
     private boolean hasConsumedExplosive = false;
+    private boolean outputBlocked = false;
     private BedrockFluidVeinSavedData cachedSavedData = null;
 
     public GasWellRecipeLogic(GasWellMachine machine) {
@@ -38,6 +39,7 @@ public class GasWellRecipeLogic {
     public void reset() {
         timer = 0;
         hasConsumedExplosive = false;
+        outputBlocked = false;
     }
 
     public void resetFull() {
@@ -108,7 +110,8 @@ public class GasWellRecipeLogic {
                 return;
 
             var toOutput = new FluidStack(veinFluid, produced);
-            if (!canOutputFluid(toOutput))
+            outputBlocked = !canOutputFluid(toOutput);
+            if (outputBlocked)
                 return; // If the output is full don't deplete the vein but keep consumming explosives and input fluid
 
             outputFluid(toOutput);

--- a/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/trait/GasWellRecipeLogic.java
+++ b/src/main/java/su/terrafirmagreg/core/common/tfgt/machine/trait/GasWellRecipeLogic.java
@@ -106,7 +106,12 @@ public class GasWellRecipeLogic {
             int produced = getFluidToProduce(entry);
             if (produced <= 0)
                 return;
-            outputFluid(new FluidStack(veinFluid, produced));
+
+            var toOutput = new FluidStack(veinFluid, produced);
+            if (!canOutputFluid(toOutput))
+                return; // If the output is full don't deplete the vein but keep consumming explosives and input fluid
+
+            outputFluid(toOutput);
             savedData.depleteVein(chunkX, chunkZ, 5, true);
         }
     }
@@ -153,6 +158,13 @@ public class GasWellRecipeLogic {
         }
 
         return false;
+    }
+
+    private boolean canOutputFluid(FluidStack fluid) {
+        var outputTank = machine.getOutputFluidTank();
+        if (outputTank == null)
+            return false;
+        return outputTank.fillInternal(fluid, IFluidHandler.FluidAction.SIMULATE) >= fluid.getAmount();
     }
 
     private void outputFluid(FluidStack fluid) {


### PR DESCRIPTION
-Stop the Gas Well to deplete the vein if Hatch full but let the explosive and water/steam being consumed
-Add more info to the GUI to let the player know what fluid they can extract and info about the hatch being full

-Vulcanizer can now parallel (may need to tweak the numbers)