### PR TITLE
Sapling Tooltips

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/TFGItemTooltipHelpers.java
+++ b/src/main/java/su/terrafirmagreg/core/client/TFGItemTooltipHelpers.java
@@ -12,6 +12,8 @@ import com.simibubi.create.foundation.utility.CreateLang;
 import net.createmod.catnip.lang.Lang;
 import net.dries007.tfc.common.blocks.devices.BellowsBlock;
 import net.dries007.tfc.common.blocks.devices.QuernBlock;
+import net.dries007.tfc.common.blocks.plant.fruit.FruitTreeSaplingBlock;
+import net.dries007.tfc.common.blocks.wood.TFCSaplingBlock;
 import net.dries007.tfc.util.Drinkable;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.registries.Registries;
@@ -33,7 +35,9 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Mod;
 
 import su.terrafirmagreg.core.TFGCore;
+import su.terrafirmagreg.core.client.util.SaplingGrowthCache;
 import su.terrafirmagreg.core.common.block.asphalt.AsphaltRoadHelper;
+import su.terrafirmagreg.core.common.block.palmtree.PalmTreeSaplingBlock;
 import su.terrafirmagreg.core.common.capability.ILargeEgg;
 import su.terrafirmagreg.core.common.capability.LargeEggCapability;
 import su.terrafirmagreg.core.common.data.TFGFluids;
@@ -112,6 +116,26 @@ public class TFGItemTooltipHelpers {
                 ).withStyle(ChatFormatting.YELLOW));
                 return;
             }
+        }
+
+        // Add Growth Time tooltip to saplings.
+        int daysToGrow = -1;
+
+        if (block instanceof TFCSaplingBlock b) {
+            daysToGrow = b.getDaysToGrow();
+        } else if (block instanceof FruitTreeSaplingBlock b) {
+            daysToGrow = b.getTreeGrowthDays();
+        } else if (block instanceof PalmTreeSaplingBlock b) {
+            daysToGrow = b.getTreeGrowthDays();
+        }
+
+        if (daysToGrow >= 0) {
+            ChatFormatting dynamicColor = SaplingGrowthCache.getGrowthColor(block);
+
+            tooltip.add(Component.translatable("tfg.tooltip.growth_time").withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal(": ")
+                            .append(Component.translatable("tfc.tooltip.time_delta_days", daysToGrow)
+                                    .withStyle(ChatFormatting.ITALIC, dynamicColor))));
         }
     }
 

--- a/src/main/java/su/terrafirmagreg/core/client/util/SaplingGrowthCache.java
+++ b/src/main/java/su/terrafirmagreg/core/client/util/SaplingGrowthCache.java
@@ -1,0 +1,101 @@
+package su.terrafirmagreg.core.client.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.dries007.tfc.common.blocks.plant.fruit.FruitTreeSaplingBlock;
+import net.dries007.tfc.common.blocks.wood.TFCSaplingBlock;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.event.AddReloadListenerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import su.terrafirmagreg.core.common.block.palmtree.PalmTreeSaplingBlock;
+
+/**
+ * Utility class for caching sapling growth days and providing tooltip color based on growth days.
+ */
+@SuppressWarnings("deprecation")
+public class SaplingGrowthCache {
+    private static final Map<Block, Integer> CACHE = new HashMap<>();
+    private static int minBound = 0;
+    private static int maxBound = 0;
+    private static boolean initialized = false;
+
+    /**
+     * Initializes the sapling growth cache if it hasn't been happened yet.
+     */
+    public static void initializeIfNeeded() {
+        if (initialized)
+            return;
+
+        int overallMin = Integer.MAX_VALUE;
+        int overallMax = Integer.MIN_VALUE;
+
+        // Cache sapling min and max growth days.
+        for (Block block : BuiltInRegistries.BLOCK) {
+            int days = -1;
+            if (block instanceof TFCSaplingBlock b)
+                days = b.getDaysToGrow();
+            else if (block instanceof FruitTreeSaplingBlock b)
+                days = b.getTreeGrowthDays();
+            else if (block instanceof PalmTreeSaplingBlock b)
+                days = b.getTreeGrowthDays();
+
+            if (days > 0) {
+                CACHE.put(block, days);
+                if (days < overallMin)
+                    overallMin = days;
+                if (days > overallMax)
+                    overallMax = days;
+            }
+        }
+
+        if (!CACHE.isEmpty()) {
+            minBound = overallMin;
+            maxBound = overallMax;
+        }
+        initialized = true;
+    }
+
+    /**
+     * Invalidates the sapling growth cache when needed.
+     */
+    public static void invalidate() {
+        CACHE.clear();
+        minBound = 0;
+        maxBound = 0;
+        initialized = false;
+    }
+
+    /**
+     * Resets the sapling growth cache during resource reloads.
+     */
+    @SubscribeEvent
+    public static void onResourceReload(AddReloadListenerEvent event) {
+        SaplingGrowthCache.invalidate();
+    }
+
+    /**
+     * Returns sapling growth color based on its growth days compared to the average.
+     */
+    public static ChatFormatting getGrowthColor(Block block) {
+        initializeIfNeeded();
+        if (!CACHE.containsKey(block) || minBound == maxBound) {
+            return ChatFormatting.GOLD;
+        }
+
+        int days = CACHE.get(block);
+        double range = maxBound - minBound;
+        double dynamicThird = range / 3.0;
+
+        if (days <= minBound + dynamicThird) {
+            return ChatFormatting.DARK_GREEN;
+        } else if (days <= minBound + (dynamicThird * 2)) {
+            return ChatFormatting.GOLD;
+        } else {
+            return ChatFormatting.DARK_RED;
+        }
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/config/ServerConfig.java
+++ b/src/main/java/su/terrafirmagreg/core/config/ServerConfig.java
@@ -40,10 +40,10 @@ public final class ServerConfig {
     public final ForgeConfigSpec.IntValue CHAMELEON_SPRAY_CAN_CAPACITY;
     public final ForgeConfigSpec.IntValue CHAMELEON_SPRAY_CAN_COST_PER_OPERATION;
     public final ForgeConfigSpec.DoubleValue CHAMELEON_SPRAY_CAN_BULK_MULTIPLIER;
-  
+
     public final ForgeConfigSpec.IntValue GLASSBLOWING_COOLDOWN;
     public final ForgeConfigSpec.IntValue GLASSBLOWING_DURATION;
-  
+
     public final ForgeConfigSpec.DoubleValue QUERN_STRESS_IMPACT;
     public final ForgeConfigSpec.IntValue QUERN_STRESS_LIMIT;
     public final ForgeConfigSpec.IntValue QUERN_RPM_LIMIT;
@@ -196,7 +196,7 @@ public final class ServerConfig {
         GLASSBLOWING_DURATION = builder
                 .comment("\nBase glassblowing duration in ticks. Default: 40, min: 2, max: maxInt")
                 .defineInRange("baseGlassblowingCooldown", 40, 2, Integer.MAX_VALUE);
-                         
+
         builder.pop().push("tfc_create_compatibility");
         QUERN_STRESS_IMPACT = builder
                 .comment("\nStress impact multiplier for the quern. Default: 0.25, min: 0, max: 64")


### PR DESCRIPTION
Adds dynamic growth time tooltips for saplings.
Calculates a cache of all growth times and seperates sapling growth time into "shorter than average", "average", and "longer than average". And changes the color of the timer based on its group. Cache is calculated on resource load.