### PR TITLE
Mixin to enable stencil texture at an early stage

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/client/minecraft/RenderTargetStencilMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/client/minecraft/RenderTargetStencilMixin.java
@@ -1,0 +1,25 @@
+package su.terrafirmagreg.core.mixins.client.minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+
+// Distant Horizons doesn't like when enableStencil() is called after it has done its own setup.
+// This patches the configured buffers before they are ever created, so that stencil support is
+// there when DH caches everything. enableStencil calls shouldn't be needed anywhere else after this.
+// This should fix our own nutrient graph, and also all TACZ scoped weapons.
+@Mixin(RenderTarget.class)
+public abstract class RenderTargetStencilMixin {
+
+    @Shadow
+    public boolean stencilEnabled;
+
+    @Inject(method = "createBuffers", at = @At("HEAD"))
+    private void tfg$forceStencil(int width, int height, boolean clearError, CallbackInfo ci) {
+        this.stencilEnabled = true;
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -5,6 +5,7 @@
         "client.minecraft.AbstractContainerScreenMixin",
         "client.minecraft.IBlockModelGeneratorsInvoker",
         "client.minecraft.MenuScreensMixin",
+        "client.minecraft.RenderTargetStencilMixin",
         "client.tfc.ClientForgeEventHandlerMixin",
         "client.tfc.DrinkableMixin",
         "client.tfc.jei.JEIIntegrationMixin",


### PR DESCRIPTION
## What is the new behavior?
Basicly does what state setup `Minecraft.getInstance().getMainRenderTarget().enableStencil();` does, but at a very early stage.

Should fix TACZ scopes and nutrients screen from corrupting Distant Horizons far chunk rendering.

## Outcome
Hovering the nutrients screen or equiping a scoped weapon should no longer break rendering.

Please test this thorougly. I didn't expect this to really work.

## Analysis
The root cause of this bug can be said to be Distant Horizons itself. Since Forge/Minecraft exposes an API which can mutate rendering state at runtime, DH should have an event listener so that it can invalidate its own cache. Should such an event API be missing, it is a shortfall with Forge, and more care and documentation needs to appear on the relevant state reading APIs to note what is invariant and what is not.