### PR TITLE
Move Earth Jellies to Axolotl Spawn Group

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -177,7 +177,7 @@ dependencies {
     modCompileOnly "curse.maven:additional-placements-674852:7905535"
 
     // Jellies
-    modImplementation "maven.modrinth:jellies:0.1.3"
+    modImplementation "maven.modrinth:jellies:0.1.6"
 
     // Create: Steam Powered, 22 jul 2026
     modImplementation "maven.modrinth:create-steam-powered:1.20.1-3.1.0"

--- a/src/main/resources/data/tfg/worldgen/biome/earth/active_shield_volcano.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/active_shield_volcano.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ancient_shield_volcano.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ancient_shield_volcano.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/badlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/badlands.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/burren_badlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/burren_badlands.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/burren_badlands_tall.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/burren_badlands_tall.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/burren_plains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/burren_plains.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/burren_plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/burren_plateau.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/burren_roche_moutonee.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/burren_roche_moutonee.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/buttes.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/buttes.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/canyons.json
@@ -134,7 +134,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/cenote_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/cenote_canyons.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/cenote_highlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/cenote_highlands.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/cenote_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/cenote_hills.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/cenote_plains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/cenote_plains.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/cenote_plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/cenote_plateau.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/cenote_rolling_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/cenote_rolling_hills.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/doline_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/doline_canyons.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/doline_highlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/doline_highlands.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/doline_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/doline_hills.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/doline_plains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/doline_plains.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/doline_plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/doline_plateau.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/doline_rolling_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/doline_rolling_hills.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/dormant_shield_volcano.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/dormant_shield_volcano.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/drumlins.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/drumlins.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/extinct_shield_volcano.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/extinct_shield_volcano.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/extreme_doline_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/extreme_doline_mountains.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/extreme_doline_plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/extreme_doline_plateau.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/glacially_carved_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/glacially_carved_mountains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/glacially_carved_oceanic_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/glacially_carved_oceanic_mountains.json
@@ -132,7 +132,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/glaciated_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/glaciated_mountains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/glaciated_oceanic_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/glaciated_oceanic_mountains.json
@@ -132,7 +132,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/glaciated_shield_volcano.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/glaciated_shield_volcano.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/grassy_dunes.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/grassy_dunes.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/guano_island.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/guano_island.json
@@ -64,12 +64,6 @@
             {
                 "weight": 100,
                 "minCount": 1,
-                "type": "jellies:phosphorum",
-                "maxCount": 2
-            },
-            {
-                "weight": 100,
-                "minCount": 1,
                 "type": "minecraft:bat",
                 "maxCount": 2
             },
@@ -80,6 +74,12 @@
                 "maxCount": 5
             }
         ],
+        "axolotls": [{
+            "weight": 100,
+            "minCount": 1,
+            "type": "jellies:phosphorum",
+            "maxCount": 2
+        }],
         "creature": [
             {
                 "weight": 1,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/highlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/highlands.json
@@ -106,7 +106,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/hills.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/hoodoos.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/hoodoos.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_edge.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_edge.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_mountains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_mountains_edge.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_mountains_edge.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_oceanic_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_oceanic_mountains.json
@@ -72,14 +72,14 @@
                 "minCount": 2,
                 "type": "fowlplay:gull",
                 "maxCount": 5
-            },
-            {
-                "weight": 100,
-                "minCount": 2,
-                "type": "jellies:rock",
-                "maxCount": 4
             }
         ],
+        "axolotls": [{
+            "weight": 100,
+            "minCount": 2,
+            "type": "jellies:rock",
+            "maxCount": 4
+        }],
         "creature": [
             {
                 "weight": 1,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_oceanic_mountains_edge.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_oceanic_mountains_edge.json
@@ -132,7 +132,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_shield_volcano.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_shield_volcano.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_tuyas.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_tuyas.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_tuyas_edge.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/ice_sheet_tuyas_edge.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/inverted_patterned_ground.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/inverted_patterned_ground.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/knob_and_kettle.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/knob_and_kettle.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/low_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/low_canyons.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/lowlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/lowlands.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/mesas.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/mesas.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/mountains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/mud_flats.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/mud_flats.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/oceanic_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/oceanic_mountains.json
@@ -132,7 +132,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/old_mountain_lake.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/old_mountain_lake.json
@@ -74,20 +74,18 @@
             "type": "tfc:manatee",
             "maxCount": 2
         }],
-        "ambient": [
-            {
-                "weight": 10,
-                "minCount": 1,
-                "type": "fowlplay:goose",
-                "maxCount": 4
-            },
-            {
-                "weight": 100,
-                "minCount": 2,
-                "type": "jellies:rock",
-                "maxCount": 4
-            }
-        ],
+        "ambient": [{
+            "weight": 10,
+            "minCount": 1,
+            "type": "fowlplay:goose",
+            "maxCount": 4
+        }],
+        "axolotls": [{
+            "weight": 100,
+            "minCount": 2,
+            "type": "jellies:rock",
+            "maxCount": 4
+        }],
         "water_ambient": [
             {
                 "weight": 10,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/old_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/old_mountains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/patterned_ground.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/patterned_ground.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/plains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/plains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/plateau.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/plateau_wide.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/plateau_wide.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/rocky_plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/rocky_plateau.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/rolling_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/rolling_hills.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/salt_marsh.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/salt_marsh.json
@@ -132,7 +132,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/shilin_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/shilin_canyons.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/shilin_highlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/shilin_highlands.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/shilin_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/shilin_hills.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/shilin_plains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/shilin_plains.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/shilin_plateau.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/shilin_plateau.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/stair_step_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/stair_step_canyons.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/stone_circles.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/stone_circles.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_canyons.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_highlands.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_highlands.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_hills.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_hills.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_plains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/tower_karst_plains.json
@@ -141,7 +141,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/tuyas.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/tuyas.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/volcanic_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/volcanic_mountains.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/volcanic_oceanic_mountains.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/volcanic_oceanic_mountains.json
@@ -132,7 +132,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,

--- a/src/main/resources/data/tfg/worldgen/biome/earth/whorled_canyons.json
+++ b/src/main/resources/data/tfg/worldgen/biome/earth/whorled_canyons.json
@@ -140,7 +140,9 @@
                 "minCount": 2,
                 "type": "fowlplay:sparrow",
                 "maxCount": 4
-            },
+            }
+        ],
+        "axolotls": [
             {
                 "weight": 30,
                 "minCount": 2,


### PR DESCRIPTION
## What is the new behavior?
Moves all earth jellies to axolotl spawn group, will do moon and mars in modpack. Beneath jellies stay as ambient.