### PR TITLE
sync worldgen version on dedicated servers

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/client/ClientWorldgenVersion.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ClientWorldgenVersion.java
@@ -1,0 +1,30 @@
+package su.terrafirmagreg.core.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import su.terrafirmagreg.core.world.new_ow_wg.WorldgenVersionData;
+
+@OnlyIn(Dist.CLIENT)
+public final class ClientWorldgenVersion {
+
+    private ClientWorldgenVersion() {
+    }
+
+    public static void apply(int overworldVersion) {
+        if (Minecraft.getInstance().hasSingleplayerServer()) {
+            return;
+        }
+        WorldgenVersionData.OVERWORLD_VERSION = overworldVersion;
+        WorldgenVersionData.OVERWORLD_SESSION_VERSION_RESOLVED = true;
+    }
+
+    public static void clear() {
+        if (Minecraft.getInstance().hasSingleplayerServer()) {
+            return;
+        }
+        WorldgenVersionData.OVERWORLD_VERSION = 0;
+        WorldgenVersionData.OVERWORLD_SESSION_VERSION_RESOLVED = false;
+    }
+}

--- a/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
+++ b/src/main/java/su/terrafirmagreg/core/client/ForgeClientEventListener.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.ComputeFovModifierEvent;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
@@ -41,6 +42,14 @@ import su.terrafirmagreg.core.common.perf.SupportCache;
 @Mod.EventBusSubscriber(modid = TFGCore.MOD_ID, value = Dist.CLIENT)
 @OnlyIn(Dist.CLIENT)
 public class ForgeClientEventListener {
+
+    /**
+     * Clear the overworld version on disconnect so it doesnt leak into next world
+     */
+    @SubscribeEvent
+    public static void onClientLoggingOut(ClientPlayerNetworkEvent.LoggingOut event) {
+        ClientWorldgenVersion.clear();
+    }
 
     /**
      * Evict client-side SupportCache chunk to prevent stale cache info.

--- a/src/main/java/su/terrafirmagreg/core/common/event/WorldgenVersionEvents.java
+++ b/src/main/java/su/terrafirmagreg/core/common/event/WorldgenVersionEvents.java
@@ -16,11 +16,14 @@ import net.minecraftforge.event.server.ServerAboutToStartEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.network.PacketDistributor;
 
 import su.terrafirmagreg.core.TFGCore;
 import su.terrafirmagreg.core.config.TFGConfig;
 import su.terrafirmagreg.core.mixins.common.minecraft.AccessorMinecraftServer;
 import su.terrafirmagreg.core.mixins.common.tfc.new_ow_wg.AccessorTFCBiomes;
+import su.terrafirmagreg.core.network.TFGNetworkHandler;
+import su.terrafirmagreg.core.network.packet.WorldgenVersionSyncPacket;
 import su.terrafirmagreg.core.world.new_ow_wg.WorldgenVersionData;
 import su.terrafirmagreg.core.world.new_ow_wg.biome.IBiomeExtension;
 import su.terrafirmagreg.core.world.new_ow_wg.rivers.TFGRiverBlendType;
@@ -125,9 +128,15 @@ public class WorldgenVersionEvents {
 
     @SubscribeEvent
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
-        if (pendingOpWarnings.isEmpty())
-            return;
         if (!(event.getEntity() instanceof ServerPlayer player))
+            return;
+
+        // The client JVM never runs ServerAboutToStartEvent, so we send OVERWORLD_VERSION here 
+        TFGNetworkHandler.INSTANCE.send(
+                PacketDistributor.PLAYER.with(() -> player),
+                new WorldgenVersionSyncPacket(WorldgenVersionData.OVERWORLD_VERSION));
+
+        if (pendingOpWarnings.isEmpty())
             return;
         final MinecraftServer server = player.getServer();
         if (server == null || !server.getPlayerList().isOp(player.getGameProfile()))

--- a/src/main/java/su/terrafirmagreg/core/network/TFGNetworkHandler.java
+++ b/src/main/java/su/terrafirmagreg/core/network/TFGNetworkHandler.java
@@ -100,6 +100,13 @@ public class TFGNetworkHandler {
                 JavelinRecallPacket::decode,
                 JavelinRecallPacket::handle,
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
+        INSTANCE.registerMessage(
+                id(),
+                WorldgenVersionSyncPacket.class,
+                WorldgenVersionSyncPacket::encode,
+                WorldgenVersionSyncPacket::decode,
+                WorldgenVersionSyncPacket::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
     }
 
     private static void sendToAllAround(Level level, BlockPos pos, Object packet) {

--- a/src/main/java/su/terrafirmagreg/core/network/packet/WorldgenVersionSyncPacket.java
+++ b/src/main/java/su/terrafirmagreg/core/network/packet/WorldgenVersionSyncPacket.java
@@ -1,0 +1,35 @@
+package su.terrafirmagreg.core.network.packet;
+
+import java.util.function.Supplier;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+
+import su.terrafirmagreg.core.client.ClientWorldgenVersion;
+
+/**
+ * Packet to send resolved OVERWORLD_VERSION on login
+ */
+public record WorldgenVersionSyncPacket(int overworldVersion) {
+
+    public static void encode(WorldgenVersionSyncPacket packet, FriendlyByteBuf buffer) {
+        buffer.writeVarInt(packet.overworldVersion);
+    }
+
+    public static WorldgenVersionSyncPacket decode(FriendlyByteBuf buffer) {
+        return new WorldgenVersionSyncPacket(buffer.readVarInt());
+    }
+
+    public static void handle(WorldgenVersionSyncPacket packet, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> handleClient(packet)));
+        ctx.get().setPacketHandled(true);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private static void handleClient(WorldgenVersionSyncPacket packet) {
+        ClientWorldgenVersion.apply(packet.overworldVersion());
+    }
+}


### PR DESCRIPTION
## What is the new behavior?

Clients on a dedicated server now get the overworld worldgen version from the server

Before this the current and average temperature followed the northern hemisphere even when you were in the south, while the player's own temperature followed the south

## Implementation Details

OVERWORLD_VERSION is only set in ServerAboutToStartEvent, which runs on the server. In singleplayer the integrated server is in the same JVM so the client sees it, but on a dedicated server the client keeps the 0 default forever and OverworldClimateModelMixin never does anything

So I added a packet that sends the version on login. It writes straight into OVERWORLD_VERSION and it also sets OVERWORLD_SESSION_VERSION_RESOLVED so a synced 0 (classic overworld) isn't mistaken for "never synced"

This probably fixes TFGEmiPlugin and FluidVeinRecipe too since they read the same static on the client, but I didn't check those in game

## Outcome

Closes TerraFirmaGreg-Team/Modpack-Modern#3732
Closes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3879

## Additional Information

Tested on a local server with a new world. Teleported to southern hemisphere and the current temperature and my own temperature agree now, same in the north with the season flipped

I haven't tested if before this change /tfg debug for the world version was already using 1 for the overworld in multiplayer, but now it definetly does.

This can't be reproduced in singleplayer, both sides share the JVM there.

Discord: ari3x_
