### PR TITLE
workaround to repair scrambled pack order at level data

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/MinecraftServerPackOrderMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/MinecraftServerPackOrderMixin.java
@@ -1,0 +1,58 @@
+package su.terrafirmagreg.core.mixins.common.minecraft;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.DataPackConfig;
+
+import su.terrafirmagreg.core.TFGCore;
+
+/**
+ * Repairs the datapack order stored in level.dat when it is scrambled. It happens at pack selection before anything is read from the packs
+ */
+@Mixin(MinecraftServer.class)
+public class MinecraftServerPackOrderMixin {
+
+    private static final String TFG$VANILLA = "vanilla";
+    private static final String TFG$MOD_PREFIX = "mod:";
+
+    /**
+     * A healthy list is vanilla>mods>packs mods generate at runtime.
+     * Vanilla sitting anywhere but first means that the list is scrambled, so we leave every other world alone.
+     */
+    @ModifyVariable(method = "configurePackRepository", at = @At("HEAD"), argsOnly = true, index = 1)
+    private static DataPackConfig tfg$repairScrambledPackOrder(DataPackConfig config) {
+        final List<String> enabled = config.getEnabled();
+        final int vanillaIndex = enabled.indexOf(TFG$VANILLA);
+
+        // Absent is fine
+        if (vanillaIndex <= 0) {
+            return config;
+        }
+
+        final List<String> mods = new ArrayList<>();
+        final List<String> generated = new ArrayList<>();
+        for (String pack : enabled) {
+            if (TFG$VANILLA.equals(pack)) {
+                continue;
+            }
+            (pack.startsWith(TFG$MOD_PREFIX) ? mods : generated).add(pack);
+        }
+
+        final List<String> repaired = new ArrayList<>(enabled.size());
+        repaired.add(TFG$VANILLA);
+        repaired.addAll(mods);
+        repaired.addAll(generated);
+
+        TFGCore.LOGGER.warn(
+                "Datapack order in this save was scrambled, vanilla was at position {} of {} and overrode mod data. Reordered it to vanilla>mods>generated packs.",
+                vanillaIndex, enabled.size());
+
+        return new DataPackConfig(repaired, config.getDisabled());
+    }
+}

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -187,6 +187,7 @@
         "common.minecraft.IBlockLootSubProviderAccessor",
         "common.minecraft.ItemStackMixin",
         "common.minecraft.MinecartFurnaceMixin",
+        "common.minecraft.MinecraftServerPackOrderMixin",
         "common.minecraft.ModelProviderMixin",
         "common.minecraft.MushroomBlockMixin",
         "common.minecraft.PoiSectionAccessor",


### PR DESCRIPTION
## What is the new behavior?

Now if vanilla is not the first pack on the datapack load order, we assume it's scrambled and reorder as vanilla>mods>mod generated packs.

It's a workaround since we don't know the reason of datapack load order being scrambled in some worlds.

## Implementation Details

Mixin on MinecraftServer.configurePackRepository, which happens before the content of the packs are actually used anywhere. Now it verify if it's scrambled and reorder. If it's not scrambled it does nothing.

## Outcome

Close TerraFirmaGreg-Team/Modpack-Modern#4152

## Additional Information

Tested on the bug reporter's world, the order was scrambled with vanilla on the position 267, after the change it works properly, the order is correct. Also loaded in a new world where the order was correct and it didn't log or changed the order.

We also log a warn when this workaround is triggered:

 TFGCore.LOGGER.warn(
                "Datapack order in this save was scrambled, vanilla was at position {} of {} and overrode mod data. Reordered it to vanilla>mods>generated packs.",
                vanillaIndex, enabled.size());

Discord: ari3x_