### PR TITLE
Add new road marking types to AsphaltRoadMarkingMask

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadMarkingMask.java
+++ b/src/main/java/su/terrafirmagreg/core/common/block/asphalt/AsphaltRoadMarkingMask.java
@@ -29,7 +29,13 @@ public enum AsphaltRoadMarkingMask implements StringRepresentable {
     NUM_7("num_7"),
     NUM_8("num_8"),
     NUM_9("num_9"),
-    NUMBER("number");
+    NUMBER("number"),
+    DIAGONAL_LINE("diagonal_line", 2),
+    FULLCORNER("fullcorner"),
+    ANGLED_EDGE_L("angled_edge_l"),
+    ANGLED_EDGE_R("angled_edge_r"),
+    CAT("cat"),
+    CREEPER("creeper");
 
     private final String name;
     private final int dirs;


### PR DESCRIPTION
Added new road marking types including diagonal line, full corner, and angled edges.


## What is the new behavior?
I added 6 new types of asphalt road markings, with 6 new types of stencils for those markings.

## Implementation Details
i changed 4 scripts, and added 12 textures (6 for the stencils, 6 for the road markings)

## Outcome
6 more types of road markings

## Additional Information
<img width="1863" height="1012" alt="image" src="https://github.com/user-attachments/assets/e9a1052e-e6da-4de3-84ad-c7f71e6fad91" />
an image containing the changes.


## Potential Compatibility Issues
theres no compatibility issues that i know of


discord nickname: DeepSpaceMan